### PR TITLE
Fix x-ui empty Phase1 when PasarGuard runs on MySQL

### DIFF
--- a/app/services/migrators/xui.py
+++ b/app/services/migrators/xui.py
@@ -4,7 +4,10 @@ Always converts to SQLite first. If target_db is not sqlite, runs two-phase
 engine to copy head→head into the requested engine.
 """
 
+from __future__ import annotations
+
 import shutil
+import sqlite3
 from pathlib import Path
 
 from app.config import PASARGUARD_DIR, PASARGUARD_DATA, PASARGUARD_ENV, TOOLS_DIR, BACKUP_DIR
@@ -33,7 +36,6 @@ def find_xui_db_in_dir(root: Path) -> Path | None:
                 fallback.append(p)
 
     if preferred:
-        # Prefer exact x-ui.db, then any *x-ui* name
         for p in preferred:
             if p.name.lower() == "x-ui.db":
                 return p
@@ -57,7 +59,6 @@ def resolve_xui_db_source(
         candidates.append(Path(upload_work_dir))
     if upload_path:
         p = Path(upload_path)
-        # Avoid scanning the same directory twice when both params point at workspace
         if not candidates or p.resolve() != candidates[0].resolve():
             candidates.append(p)
 
@@ -70,17 +71,111 @@ def resolve_xui_db_source(
                 return found
             continue
         if src.is_file():
-            suffix = src.suffix.lower()
-            if suffix == ".zip":
-                # Caller extracts zip; signal zip by returning the zip path.
-                # Actual extraction stays in the migrator (needs async unzip).
-                return src
-            if suffix in (".db", ".sqlite3") or "x-ui" in src.name.lower():
-                return src
-            # Unknown single file — still try (legacy upload of bare db)
             return src
 
     return find_xui_db()
+
+
+def bundled_xui_schema_db(tools_dir: Path | None = None) -> Path | None:
+    """Official empty PasarGuard SQLite schema shipped with PasarGuard/migrations."""
+    base = Path(tools_dir) if tools_dir else TOOLS_DIR
+    path = base / "migrations" / "x-ui" / "input-db-pg" / "db.sqlite3"
+    return path if path.is_file() else None
+
+
+def resolve_xui_schema_db(
+    tools_dir: Path | None = None,
+    pasarguard_data: Path | None = None,
+) -> Path:
+    """Pick a PasarGuard *SQLite* schema reference for the official x-ui migrator.
+
+    Starting a MySQL/Postgres PasarGuard install never creates db.sqlite3, so we
+    must not rely on safe_start for schema creation. Prefer the bundled empty
+    schema from PasarGuard/migrations; fall back to a live sqlite file if present.
+    """
+    bundled = bundled_xui_schema_db(tools_dir)
+    if bundled:
+        return bundled
+
+    data = Path(pasarguard_data) if pasarguard_data else PASARGUARD_DATA
+    live = data / "db.sqlite3"
+    if live.is_file() and live.stat().st_size > 0:
+        return live
+
+    raise RuntimeError(
+        "PasarGuard SQLite schema reference not found. "
+        "Expected tools/migrations/x-ui/input-db-pg/db.sqlite3 "
+        "(re-run installer to fetch PasarGuard/migrations) "
+        "or a local /var/lib/pasarguard/db.sqlite3."
+    )
+
+
+def _table_count(conn: sqlite3.Connection, table: str) -> int | None:
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        if not row or row[0] == 0:
+            return None
+        return int(conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
+    except sqlite3.Error:
+        return None
+
+
+def inspect_xui_sqlite(path: Path) -> dict[str, int]:
+    """Count key x-ui source tables (client_traffics / clients / inbounds)."""
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        out: dict[str, int] = {}
+        for table in ("client_traffics", "clients", "inbounds", "users"):
+            n = _table_count(conn, table)
+            if n is not None:
+                out[table] = n
+        return out
+    finally:
+        conn.close()
+
+
+def inspect_pasarguard_sqlite(path: Path) -> dict[str, int]:
+    """Count key PasarGuard tables in a migrated sqlite file."""
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        out: dict[str, int] = {}
+        for table in ("users", "admins", "hosts", "inbounds", "nodes", "groups"):
+            n = _table_count(conn, table)
+            if n is not None:
+                out[table] = n
+        return out
+    finally:
+        conn.close()
+
+
+def assert_xui_source_has_data(path: Path) -> dict[str, int]:
+    counts = inspect_xui_sqlite(path)
+    if not counts:
+        raise RuntimeError(
+            "فایل x-ui.db جدول‌های مورد انتظار (inbounds / client_traffics) را ندارد — "
+            "آیا فایل دیتابیس 3x-ui درست آپلود شده؟"
+        )
+    clients = counts.get("client_traffics", counts.get("clients", 0))
+    inbounds = counts.get("inbounds", 0)
+    if clients <= 0 and inbounds <= 0:
+        raise RuntimeError(
+            "دیتابیس x-ui.db خالی است (هیچ inbound/کاربری نیست) — مهاجرت لغو شد"
+        )
+    return counts
+
+
+def assert_migrated_pg_has_data(path: Path) -> dict[str, int]:
+    counts = inspect_pasarguard_sqlite(path)
+    data_tables = ("users", "inbounds", "groups")
+    if any(counts.get(t, 0) > 0 for t in data_tables):
+        return counts
+    raise RuntimeError(
+        "خروجی مهاجرت x-ui خالی است (users/inbounds/groups = 0). "
+        "معمولاً به‌خاطر نبود schema مرجع SQLite یا دیتابیس مبدأ خالی است."
+    )
 
 
 class XuiMigrator(BaseMigrator):
@@ -98,22 +193,23 @@ class XuiMigrator(BaseMigrator):
             raise RuntimeError("دیتابیس x-ui.db یافت نشد — لطفاً آپلود کنید")
 
         self.job.log(f"Using 3x-ui database: {xui_db}")
+        src_counts = assert_xui_source_has_data(Path(xui_db))
+        self.job.log(
+            "Source x-ui counts: "
+            + ", ".join(f"{k}={v}" for k, v in src_counts.items())
+        )
 
         self.job.set_progress(15, "بررسی PasarGuard...")
         if not PASARGUARD_DIR.exists():
             raise RuntimeError("PasarGuard نصب نیست — ابتدا نصب کنید")
 
-        schema_db = PASARGUARD_DATA / "db.sqlite3"
-        if not schema_db.exists():
-            self.job.log("راه‌اندازی PasarGuard برای ایجاد schema...")
-            await safe_start_pasarguard(self)
-            import asyncio
-            await asyncio.sleep(10)
-
         self.job.set_progress(30, "آماده‌سازی ابزار مهاجرت x-ui...")
         xui_tool = TOOLS_DIR / "migrations" / "x-ui"
         if not xui_tool.exists():
             raise RuntimeError("ابزار x-ui migration یافت نشد")
+
+        schema_db = resolve_xui_schema_db()
+        self.job.log(f"Using PasarGuard schema reference: {schema_db}")
 
         work_dir = BACKUP_DIR / f"xui-{self.job.job_id}"
         work_dir.mkdir(parents=True, exist_ok=True)
@@ -138,16 +234,25 @@ class XuiMigrator(BaseMigrator):
         if not output_db.exists():
             raise RuntimeError("دیتابیس خروجی ایجاد نشد")
 
+        out_counts = assert_migrated_pg_has_data(output_db)
+        self.job.log(
+            "Migrated SQLite counts: "
+            + ", ".join(f"{k}={v}" for k, v in out_counts.items())
+        )
+
+        # Land migrated SQLite under PasarGuard data (also intermediate for cross-db)
+        land_db = PASARGUARD_DATA / "db.sqlite3"
+        PASARGUARD_DATA.mkdir(parents=True, exist_ok=True)
         self.job.set_progress(70, "جایگزینی دیتابیس PasarGuard (SQLite)...")
-        self._backup_file(schema_db, BACKUP_DIR)
-        shutil.copy2(output_db, schema_db)
+        self._backup_file(land_db, BACKUP_DIR)
+        shutil.copy2(output_db, land_db)
 
         self.job.set_progress(80, "تولید mapping لینک‌های اشتراک...")
         mapping_file = work_dir / "subscription_url_mapping.json"
         await self._run_cmd(
             ["uv", "run", "migration/generate_subscription_url_mapping.py",
              "--xui-db", str(input_db),
-             "--pasarguard-db", str(schema_db),
+             "--pasarguard-db", str(land_db),
              "--output", str(mapping_file)],
             cwd=str(xui_tool),
         )
@@ -164,7 +269,7 @@ class XuiMigrator(BaseMigrator):
 
         if target_db != "sqlite":
             self.job.set_progress(88, f"Two-phase: SQLite → {target_db}...")
-            await run_cross_db_migration(self, str(schema_db), "sqlite", target_db)
+            await run_cross_db_migration(self, str(land_db), "sqlite", target_db)
             if PASARGUARD_ENV.exists():
                 from app.services.db_credentials import get_target_connection
                 text = PASARGUARD_ENV.read_text(encoding="utf-8", errors="ignore")
@@ -186,6 +291,8 @@ class XuiMigrator(BaseMigrator):
             "redirect_installed": redirect_installed,
             "target_db": target_db,
             "mapping_file": str(mapping_file) if mapping_file.exists() else None,
+            "source_counts": src_counts,
+            "migrated_counts": out_counts,
             "warnings": {
                 "en": [
                     "Old /sub/{token} links work if redirect server is installed (enabled by default).",

--- a/tests/test_xui_migrator.py
+++ b/tests/test_xui_migrator.py
@@ -1,6 +1,7 @@
 """Tests for 3x-ui DB resolution (bundle workspace vs file vs zip)."""
 
 import asyncio
+import sqlite3
 import sys
 import tempfile
 import zipfile
@@ -13,11 +14,48 @@ sys.path.insert(0, str(ROOT))
 from app.services.migrators.xui import (
     find_xui_db_in_dir,
     resolve_xui_db_source,
+    resolve_xui_schema_db,
+    bundled_xui_schema_db,
+    assert_xui_source_has_data,
+    assert_migrated_pg_has_data,
     XuiMigrator,
 )
 from app.services.migrators.base import MigrationJob
 from app.services.upload_bundle import init_bundle, save_bundle_slot, prepare_bundle_workspace
 from app.services.upload_requirements import get_upload_requirements
+
+
+def _make_xui_db(path: Path, clients: int = 1, inbounds: int = 1) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE inbounds (id INTEGER PRIMARY KEY, remark TEXT)")
+    conn.execute(
+        "CREATE TABLE client_traffics (id INTEGER PRIMARY KEY, email TEXT, inbound_id INTEGER)"
+    )
+    for i in range(inbounds):
+        conn.execute("INSERT INTO inbounds VALUES (?, ?)", (i + 1, f"in{i}"))
+    for i in range(clients):
+        conn.execute(
+            "INSERT INTO client_traffics VALUES (?, ?, ?)",
+            (i + 1, f"u{i}@t.com", 1),
+        )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _make_pg_sqlite(path: Path, users: int = 1, inbounds: int = 1) -> Path:
+    conn = sqlite3.connect(path)
+    for table in ("users", "admins", "hosts", "inbounds", "nodes", "groups"):
+        conn.execute(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY)")
+    for i in range(users):
+        conn.execute("INSERT INTO users VALUES (?)", (i + 1,))
+    for i in range(inbounds):
+        conn.execute("INSERT INTO inbounds VALUES (?)", (i + 1,))
+    if users or inbounds:
+        conn.execute("INSERT INTO groups VALUES (1)")
+    conn.commit()
+    conn.close()
+    return path
 
 
 def test_find_xui_db_prefers_named_file():
@@ -130,7 +168,6 @@ def test_bundle_database_slot_preserves_xui_db_name():
     assert (work / "x-ui.db").exists()
     assert (work / "x-ui.db").read_bytes() == b"xui-sqlite"
 
-    # Same path the API passes into the migrator
     resolved = resolve_xui_db_source(str(work), str(work))
     assert resolved == work / "x-ui.db"
 
@@ -169,13 +206,87 @@ def test_xui_upload_requirements_always_have_slots():
         assert "database" in ids
 
 
+def test_schema_prefers_bundled_over_missing_live_sqlite():
+    """MySQL PasarGuard installs have no db.sqlite3 — use bundled schema."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tools = Path(tmp) / "tools"
+        bundled = tools / "migrations" / "x-ui" / "input-db-pg" / "db.sqlite3"
+        bundled.parent.mkdir(parents=True)
+        bundled.write_bytes(b"schema")
+        data = Path(tmp) / "pasarguard-data"  # empty — simulates MySQL install
+        data.mkdir()
+
+        resolved = resolve_xui_schema_db(tools_dir=tools, pasarguard_data=data)
+        assert resolved == bundled
+        assert bundled_xui_schema_db(tools) == bundled
+
+
+def test_schema_falls_back_to_live_sqlite():
+    with tempfile.TemporaryDirectory() as tmp:
+        tools = Path(tmp) / "tools"
+        tools.mkdir()
+        data = Path(tmp) / "data"
+        data.mkdir()
+        live = data / "db.sqlite3"
+        live.write_bytes(b"live-schema")
+
+        resolved = resolve_xui_schema_db(tools_dir=tools, pasarguard_data=data)
+        assert resolved == live
+
+
+def test_schema_missing_raises_clear_error():
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            resolve_xui_schema_db(
+                tools_dir=Path(tmp) / "tools",
+                pasarguard_data=Path(tmp) / "data",
+            )
+            raise AssertionError("expected RuntimeError")
+        except RuntimeError as e:
+            assert "schema reference" in str(e).lower() or "input-db-pg" in str(e)
+
+
+def test_assert_xui_source_has_data():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = _make_xui_db(Path(tmp) / "x-ui.db", clients=3, inbounds=2)
+        counts = assert_xui_source_has_data(db)
+        assert counts["client_traffics"] == 3
+        assert counts["inbounds"] == 2
+
+        empty = Path(tmp) / "empty.db"
+        conn = sqlite3.connect(empty)
+        conn.execute("CREATE TABLE inbounds (id INTEGER PRIMARY KEY)")
+        conn.execute("CREATE TABLE client_traffics (id INTEGER PRIMARY KEY, email TEXT)")
+        conn.commit()
+        conn.close()
+        try:
+            assert_xui_source_has_data(empty)
+            raise AssertionError("expected empty source error")
+        except RuntimeError as e:
+            assert "خالی" in str(e)
+
+
+def test_assert_migrated_pg_has_data():
+    with tempfile.TemporaryDirectory() as tmp:
+        ok = _make_pg_sqlite(Path(tmp) / "ok.sqlite3", users=2, inbounds=1)
+        counts = assert_migrated_pg_has_data(ok)
+        assert counts["users"] == 2
+
+        empty = _make_pg_sqlite(Path(tmp) / "empty.sqlite3", users=0, inbounds=0)
+        try:
+            assert_migrated_pg_has_data(empty)
+            raise AssertionError("expected empty output error")
+        except RuntimeError as e:
+            assert "خالی" in str(e) or "0" in str(e)
+
+
 def test_run_does_not_copy2_directory():
     """End-to-end guard: run() must fail past DB locate without IsADirectoryError."""
     async def _run():
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp) / "workspace"
             workspace.mkdir()
-            (workspace / "x-ui.db").write_bytes(b"xui")
+            _make_xui_db(workspace / "x-ui.db")
 
             job = MigrationJob(job_id="testxui3")
             migrator = XuiMigrator(job, {
@@ -184,7 +295,6 @@ def test_run_does_not_copy2_directory():
                 "target_db": "sqlite",
             })
 
-            # PasarGuard not installed → should raise clear RuntimeError after locate
             with patch("app.services.migrators.xui.PASARGUARD_DIR", Path(tmp) / "missing-pg"):
                 with patch("app.services.migrators.xui.BACKUP_DIR", Path(tmp) / "backups"):
                     try:
@@ -198,8 +308,79 @@ def test_run_does_not_copy2_directory():
                         assert "PasarGuard" in str(e)
                         assert "IsADirectory" not in str(e)
 
-            # Confirm input was staged as a file copy, not attempted on the directory
             assert any("Using 3x-ui database" in line for line in job.logs)
+            assert any("Source x-ui counts" in line for line in job.logs)
+
+    asyncio.run(_run())
+
+
+def test_run_uses_bundled_schema_not_mysql_start():
+    """Regression: MySQL PG install must not start panel just to invent db.sqlite3."""
+    async def _run():
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            workspace.mkdir()
+            _make_xui_db(workspace / "x-ui.db", clients=2, inbounds=1)
+
+            tools = Path(tmp) / "tools"
+            schema = tools / "migrations" / "x-ui" / "input-db-pg" / "db.sqlite3"
+            schema.parent.mkdir(parents=True)
+            # minimal schema file for path resolution (migrate itself is mocked)
+            schema.write_bytes(b"x")
+            (tools / "migrations" / "x-ui").mkdir(parents=True, exist_ok=True)
+
+            pg_dir = Path(tmp) / "opt" / "pasarguard"
+            pg_dir.mkdir(parents=True)
+            data = Path(tmp) / "var" / "lib" / "pasarguard"
+            data.mkdir(parents=True)  # no db.sqlite3 → MySQL-style install
+
+            job = MigrationJob(job_id="testxui4")
+            migrator = XuiMigrator(job, {
+                "upload_path": str(workspace),
+                "upload_work_dir": str(workspace),
+                "target_db": "mysql",
+            })
+
+            started = {"n": 0}
+
+            async def _fake_start(_self):
+                started["n"] += 1
+
+            async def _fake_cmd(self, cmd, cwd=None, timeout=600):
+                if cmd and cmd[0] == "uv" and "migrate.py" in cmd:
+                    out_folder = Path(cmd[cmd.index("--output-folder") + 1])
+                    out_folder.mkdir(parents=True, exist_ok=True)
+                    _make_pg_sqlite(out_folder / "db.sqlite3", users=2, inbounds=1)
+                    return True, "ok"
+                return True, "ok"
+
+            async def _fake_cross_db(*_a, **_k):
+                raise RuntimeError("cross-db-called")
+
+            with patch("app.services.migrators.xui.PASARGUARD_DIR", pg_dir), \
+                 patch("app.services.migrators.xui.PASARGUARD_DATA", data), \
+                 patch("app.services.migrators.xui.PASARGUARD_ENV", pg_dir / ".env"), \
+                 patch("app.services.migrators.xui.TOOLS_DIR", tools), \
+                 patch("app.services.migrators.xui.BACKUP_DIR", Path(tmp) / "backups"), \
+                 patch.object(XuiMigrator, "_run_cmd", _fake_cmd), \
+                 patch("app.services.migrators.xui.safe_start_pasarguard", _fake_start), \
+                 patch("app.services.migrators.xui.run_cross_db_migration", _fake_cross_db):
+                try:
+                    await migrator.run({
+                        "upload_path": str(workspace),
+                        "upload_work_dir": str(workspace),
+                        "target_db": "mysql",
+                        "install_redirect": False,
+                    })
+                    raise AssertionError("expected cross-db-called")
+                except RuntimeError as e:
+                    assert "cross-db-called" in str(e)
+
+            # Must use bundled schema; must NOT start PG before migrate for schema inventing
+            assert started["n"] == 0
+            assert any("input-db-pg" in line for line in job.logs)
+            assert any("Migrated SQLite counts" in line for line in job.logs)
+            assert (data / "db.sqlite3").exists()
 
     asyncio.run(_run())
 
@@ -217,5 +398,11 @@ if __name__ == "__main__":
     test_bundle_database_slot_preserves_xui_db_name()
     test_bundle_zip_slot_xui()
     test_xui_upload_requirements_always_have_slots()
+    test_schema_prefers_bundled_over_missing_live_sqlite()
+    test_schema_falls_back_to_live_sqlite()
+    test_schema_missing_raises_clear_error()
+    test_assert_xui_source_has_data()
+    test_assert_migrated_pg_has_data()
     test_run_does_not_copy2_directory()
+    test_run_uses_bundled_schema_not_mysql_start()
     print("\nAll x-ui migrator tests passed.")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
After the workspace-path fix, 3x-ui → PasarGuard (MySQL target) failed with:

```text
Phase1 intermediate has 0 rows in users/admins/hosts/inbounds/nodes/groups
— refusing to wipe target and copy nothing
```

Logs showed the wizard starting Docker MySQL/PasarGuard “to create schema”. That never creates `/var/lib/pasarguard/db.sqlite3` on non-SQLite installs. The official x-ui migrator then ran without a real schema reference and produced an empty SQLite, which Phase1 correctly refused to copy.

## Fix (scoped to `XuiMigrator`)
- Prefer bundled schema: `tools/migrations/x-ui/input-db-pg/db.sqlite3`
- Fall back to live `db.sqlite3` only if it already exists
- Stop starting the panel just to invent a SQLite schema
- Validate source `x-ui.db` (`client_traffics` / `inbounds`) and migrated output before cross-DB

## Tests
```text
pytest tests/test_xui_migrator.py tests/test_upload_bundle.py tests/test_backup_analyzer.py tests/test_migration_logic.py -v
→ 49 passed
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc11a-6bbf-702b-b7bf-16b29a335207?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc11a-6bbf-702b-b7bf-16b29a335207&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

