### PR TITLE
Fix 3x-ui MySQL probe and empty core_configs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v1.7`** — Always take a full backup before restore or migration.
+> ⚠️ **`v1.8`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -55,6 +55,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v1.8 | Fix 3x-ui → MySQL migration (DB credential probe + core_configs) |
 | v1.7 | Fix 3x-ui migration crash on bundle workspace uploads (IsADirectoryError) |
 | v1.6beta | Redesigned DB info card, iOS toggle for nodes, new logo |
 | v1.5beta | Disable nodes after restore option, DB info card on upload |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v1.7`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v1.8`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -57,6 +57,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v1.8 | رفع مهاجرت 3x-ui به MySQL (پروب DB + core_configs) |
 | v1.7 | رفع خطای مهاجرت 3x-ui هنگام آپلود bundle (IsADirectoryError) |
 | v1.6beta | بهبود UI کارت DB، سوییچ iOS برای نودها، لوگو جدید |
 | v1.5beta | گزینه غیرفعال‌سازی نودها، نمایش مشخصات DB بعد آپلود |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v1.7`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v1.8`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -55,6 +55,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v1.8 | Исправление миграции 3x-ui → MySQL (probe БД + core_configs) |
 | v1.7 | Исправление ошибки миграции 3x-ui при загрузке bundle (IsADirectoryError) |
 | v1.6beta | Новый дизайн карточки БД, iOS-переключатель для узлов, новый логотип |
 | v1.5beta | Опция отключения узлов после восстановления, карточка БД при загрузке |

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "1.7"
+APP_VERSION = "1.8"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/services/migrators/base.py
+++ b/app/services/migrators/base.py
@@ -53,14 +53,34 @@ class BaseMigrator(ABC):
     async def run(self, params: dict) -> dict:
         pass
 
-    async def _run_cmd(self, cmd: list[str], cwd: str | None = None, timeout: int = 600) -> tuple[bool, str]:
-        self.job.log(f"$ {' '.join(cmd)}")
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            cwd=cwd,
-        )
+    async def _run_cmd(
+        self,
+        cmd: list[str] | str,
+        cwd: str | None = None,
+        timeout: int = 600,
+    ) -> tuple[bool, str]:
+        """Run a command as argv list (exec) or shell string.
+
+        ``db_auth`` probes pass shell strings (``cd ... && docker compose exec...``).
+        Passing those to ``create_subprocess_exec`` iterates the string character-by-
+        character and fails with FileNotFoundError — same shell support as restore.
+        """
+        if isinstance(cmd, str):
+            self.job.log(f"$ {cmd}")
+            proc = await asyncio.create_subprocess_shell(
+                cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=cwd,
+            )
+        else:
+            self.job.log(f"$ {' '.join(cmd)}")
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=cwd,
+            )
         output_lines = []
 
         async def _drain_stdout() -> None:

--- a/app/services/migrators/xui.py
+++ b/app/services/migrators/xui.py
@@ -178,6 +178,120 @@ def assert_migrated_pg_has_data(path: Path) -> dict[str, int]:
     )
 
 
+# Upstream PasarGuard/migrations bug: debug logs reference `tag` before assignment
+# whenever stream_settings has externalProxy / tlsSettings / security.
+_XUI_TAG_BUG_NEEDLE = 'logger.debug(f"Removed externalProxy from inbound {tag}")'
+_XUI_TAG_BUG_MARKER = (
+    'tag = inbound_row.get("tag", f"inbound-{inbound_row.get(\'id\', \'unknown\')}")'
+)
+
+
+def patch_xui_converter_tag_bug(xui_tool: Path) -> bool:
+    """Fix UnboundLocalError on `tag` in official x-ui converter (in-place).
+
+    Returns True if the file was patched, False if already fixed / not present.
+    """
+    path = Path(xui_tool) / "migration" / "transformers" / "converter.py"
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    if _XUI_TAG_BUG_NEEDLE not in text:
+        return False
+
+    # Already fixed: tag assignment appears before the first debug that uses it.
+    needle_pos = text.find(_XUI_TAG_BUG_NEEDLE)
+    assign_pos = text.find(_XUI_TAG_BUG_MARKER)
+    if assign_pos != -1 and assign_pos < needle_pos:
+        return False
+
+    buggy = (
+        "            # Remove external proxy and TLS settings from streamSettings if present\n"
+        "            if isinstance(stream_settings, dict):\n"
+        "                # Remove proxy-related settings\n"
+        '                stream_settings.pop("proxySettings", None)\n'
+        '                stream_settings.pop("sockopt", None)\n'
+        "                # Remove external proxy\n"
+        '                if "externalProxy" in stream_settings:\n'
+        '                    stream_settings.pop("externalProxy")\n'
+        '                    logger.debug(f"Removed externalProxy from inbound {tag}")\n'
+        "                # Remove TLS settings (certificate files won't exist on new system)\n"
+        '                if "tlsSettings" in stream_settings:\n'
+        '                    stream_settings.pop("tlsSettings")\n'
+        '                    logger.debug(f"Removed tlsSettings from inbound {tag}")\n'
+        "                # Remove security field (TLS indicator)\n"
+        '                if "security" in stream_settings:\n'
+        '                    stream_settings.pop("security")\n'
+        '                    logger.debug(f"Removed security field from inbound {tag}")\n'
+        "            \n"
+        '            tag = inbound_row.get("tag", f"inbound-{inbound_row.get(\'id\', \'unknown\')}")\n'
+    )
+    fixed = (
+        '            tag = inbound_row.get("tag", f"inbound-{inbound_row.get(\'id\', \'unknown\')}")\n'
+        "            # Remove external proxy and TLS settings from streamSettings if present\n"
+        "            if isinstance(stream_settings, dict):\n"
+        "                # Remove proxy-related settings\n"
+        '                stream_settings.pop("proxySettings", None)\n'
+        '                stream_settings.pop("sockopt", None)\n'
+        "                # Remove external proxy\n"
+        '                if "externalProxy" in stream_settings:\n'
+        '                    stream_settings.pop("externalProxy")\n'
+        '                    logger.debug(f"Removed externalProxy from inbound {tag}")\n'
+        "                # Remove TLS settings (certificate files won't exist on new system)\n"
+        '                if "tlsSettings" in stream_settings:\n'
+        '                    stream_settings.pop("tlsSettings")\n'
+        '                    logger.debug(f"Removed tlsSettings from inbound {tag}")\n'
+        "                # Remove security field (TLS indicator)\n"
+        '                if "security" in stream_settings:\n'
+        '                    stream_settings.pop("security")\n'
+        '                    logger.debug(f"Removed security field from inbound {tag}")\n'
+        "\n"
+    )
+    if buggy not in text:
+        # Fallback: move assignment before stream_settings cleanup, drop the late assign.
+        marker = "            # Remove external proxy and TLS settings from streamSettings if present\n"
+        late = (
+            '            tag = inbound_row.get("tag", f"inbound-{inbound_row.get(\'id\', \'unknown\')}")\n'
+            '            protocol = inbound_row.get("protocol", "vless")\n'
+        )
+        if marker not in text or late not in text:
+            return False
+        text2 = text.replace(
+            marker,
+            '            tag = inbound_row.get("tag", f"inbound-{inbound_row.get(\'id\', \'unknown\')}")\n'
+            + marker,
+            1,
+        )
+        text2 = text2.replace(
+            late,
+            '            protocol = inbound_row.get("protocol", "vless")\n',
+            1,
+        )
+        if text2 == text:
+            return False
+        path.write_text(text2, encoding="utf-8")
+        return True
+
+    path.write_text(text.replace(buggy, fixed, 1), encoding="utf-8")
+    return True
+
+
+def assert_migrated_core_config(path: Path) -> None:
+    """Refuse to continue if official migrator skipped core_configs (broken xray config)."""
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        n = _table_count(conn, "core_configs")
+        if n is None:
+            return  # schema without table — nothing to assert
+        if n <= 0:
+            raise RuntimeError(
+                "مهاجرت x-ui جدول core_configs را خالی گذاشت "
+                "(باگ tag در converter رسمی). دوباره تلاش کنید؛ "
+                "بدون core_config پنل inboundها را درست لود نمی‌کند."
+            )
+    finally:
+        conn.close()
+
+
 class XuiMigrator(BaseMigrator):
     async def run(self, params: dict) -> dict:
         upload_path = params.get("upload_path")
@@ -208,6 +322,11 @@ class XuiMigrator(BaseMigrator):
         if not xui_tool.exists():
             raise RuntimeError("ابزار x-ui migration یافت نشد")
 
+        if patch_xui_converter_tag_bug(xui_tool):
+            self.job.log(
+                "Patched official x-ui converter: assign inbound tag before stream_settings cleanup"
+            )
+
         schema_db = resolve_xui_schema_db()
         self.job.log(f"Using PasarGuard schema reference: {schema_db}")
 
@@ -229,12 +348,19 @@ class XuiMigrator(BaseMigrator):
         )
         if not ok:
             raise RuntimeError(f"مهاجرت x-ui ناموفق: {out}")
+        # Official tool can exit 0 even when core_configs failed (UnboundLocalError).
+        if out and "Failed to migrate core_configs" in out:
+            raise RuntimeError(
+                "مهاجرت x-ui برای core_configs شکست خورد "
+                f"(معمولاً باگ tag در converter): {out[-800:]}"
+            )
 
         output_db = output_dir / "db.sqlite3"
         if not output_db.exists():
             raise RuntimeError("دیتابیس خروجی ایجاد نشد")
 
         out_counts = assert_migrated_pg_has_data(output_db)
+        assert_migrated_core_config(output_db)
         self.job.log(
             "Migrated SQLite counts: "
             + ", ".join(f"{k}={v}" for k, v in out_counts.items())

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="1.7"
+readonly SCRIPT_VERSION="1.8"
 readonly INSTALL_DIR="/opt/pg-migrator"
 readonly SERVICE_NAME="pg-migrator"
 readonly WEB_PORT=7000

--- a/tests/test_db_auth.py
+++ b/tests/test_db_auth.py
@@ -147,6 +147,68 @@ def test_explain_auth_mariadb_target_from_timescale():
     print("OK: timescale→mariadb auth tips are MySQL-aware")
 
 
+def test_mysql_probe_shell_string_via_base_migrator():
+    """Regression: x-ui→MySQL died because BaseMigrator exec'd shell strings char-by-char."""
+    import asyncio
+    from unittest.mock import patch
+
+    from app.services.db_auth import resolve_live_admin_connection
+    from app.services.migrators.base import BaseMigrator, MigrationJob
+
+    class Dummy(BaseMigrator):
+        async def run(self, params):
+            return {}
+
+    async def _run():
+        job = MigrationJob(job_id="probe1")
+        migrator = Dummy(job, {})
+        env = "MYSQL_ROOT_PASSWORD=secret\nMYSQL_DATABASE=pasarguard\n"
+        seen = {"shell": 0}
+
+        class FakeProc:
+            returncode = 0
+
+            def __init__(self):
+                class Out:
+                    async def readline(self_inner):
+                        if not getattr(self_inner, "_sent", False):
+                            self_inner._sent = True
+                            return b"1\n"
+                        return b""
+
+                self.stdout = Out()
+
+            async def wait(self):
+                return 0
+
+            def kill(self):
+                pass
+
+        async def fake_shell(cmd, **kwargs):
+            seen["shell"] += 1
+            assert isinstance(cmd, str)
+            assert "docker compose exec" in cmd
+            assert "mysql" in cmd or "mariadb" in cmd
+            return FakeProc()
+
+        async def fake_exec(*_a, **_k):
+            raise AssertionError("probe must use create_subprocess_shell for shell strings")
+
+        with patch("app.services.db_auth.PASARGUARD_DIR", Path("/opt/pasarguard")), \
+             patch("app.services.db_auth.resolve_db_service", return_value="mysql"), \
+             patch("asyncio.create_subprocess_shell", fake_shell), \
+             patch("asyncio.create_subprocess_exec", fake_exec):
+            conn = await resolve_live_admin_connection(migrator, "mysql", env_text=env)
+
+        assert conn["password"] == "secret"
+        assert conn["user"] == "root"
+        assert seen["shell"] >= 1
+        assert not any("$ c d" in line for line in job.logs)
+
+    asyncio.run(_run())
+    print("OK: mysql probe uses shell via BaseMigrator")
+
+
 if __name__ == "__main__":
     test_postgres_password_candidates_order()
     test_postgres_admin_users()
@@ -157,4 +219,5 @@ if __name__ == "__main__":
     test_mysql_password_candidates()
     test_mysql_password_candidates_from_sqlalchemy_url()
     test_explain_auth_mariadb_target_from_timescale()
+    test_mysql_probe_shell_string_via_base_migrator()
     print("\nAll db_auth tests passed")

--- a/tests/test_xui_migrator.py
+++ b/tests/test_xui_migrator.py
@@ -18,6 +18,8 @@ from app.services.migrators.xui import (
     bundled_xui_schema_db,
     assert_xui_source_has_data,
     assert_migrated_pg_has_data,
+    assert_migrated_core_config,
+    patch_xui_converter_tag_bug,
     XuiMigrator,
 )
 from app.services.migrators.base import MigrationJob
@@ -43,14 +45,16 @@ def _make_xui_db(path: Path, clients: int = 1, inbounds: int = 1) -> Path:
     return path
 
 
-def _make_pg_sqlite(path: Path, users: int = 1, inbounds: int = 1) -> Path:
+def _make_pg_sqlite(path: Path, users: int = 1, inbounds: int = 1, core_configs: int = 1) -> Path:
     conn = sqlite3.connect(path)
-    for table in ("users", "admins", "hosts", "inbounds", "nodes", "groups"):
+    for table in ("users", "admins", "hosts", "inbounds", "nodes", "groups", "core_configs"):
         conn.execute(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY)")
     for i in range(users):
         conn.execute("INSERT INTO users VALUES (?)", (i + 1,))
     for i in range(inbounds):
         conn.execute("INSERT INTO inbounds VALUES (?)", (i + 1,))
+    for i in range(core_configs):
+        conn.execute("INSERT INTO core_configs VALUES (?)", (i + 1,))
     if users or inbounds:
         conn.execute("INSERT INTO groups VALUES (1)")
     conn.commit()
@@ -385,6 +389,111 @@ def test_run_uses_bundled_schema_not_mysql_start():
     asyncio.run(_run())
 
 
+def test_patch_xui_converter_tag_bug_moves_assignment():
+    """Upstream uses `tag` in debug logs before assignment when externalProxy exists."""
+    buggy = '''
+            # Remove external proxy and TLS settings from streamSettings if present
+            if isinstance(stream_settings, dict):
+                # Remove proxy-related settings
+                stream_settings.pop("proxySettings", None)
+                stream_settings.pop("sockopt", None)
+                # Remove external proxy
+                if "externalProxy" in stream_settings:
+                    stream_settings.pop("externalProxy")
+                    logger.debug(f"Removed externalProxy from inbound {tag}")
+                # Remove TLS settings (certificate files won't exist on new system)
+                if "tlsSettings" in stream_settings:
+                    stream_settings.pop("tlsSettings")
+                    logger.debug(f"Removed tlsSettings from inbound {tag}")
+                # Remove security field (TLS indicator)
+                if "security" in stream_settings:
+                    stream_settings.pop("security")
+                    logger.debug(f"Removed security field from inbound {tag}")
+            
+            tag = inbound_row.get("tag", f"inbound-{inbound_row.get('id', 'unknown')}")
+            protocol = inbound_row.get("protocol", "vless")
+'''
+    with tempfile.TemporaryDirectory() as tmp:
+        tool = Path(tmp) / "x-ui"
+        conv = tool / "migration" / "transformers" / "converter.py"
+        conv.parent.mkdir(parents=True)
+        conv.write_text("prefix\n" + buggy + "\nsuffix\n", encoding="utf-8")
+        assert patch_xui_converter_tag_bug(tool) is True
+        text = conv.read_text(encoding="utf-8")
+        assign = text.find(
+            'tag = inbound_row.get("tag", f"inbound-{inbound_row.get(\'id\', \'unknown\')}")'
+        )
+        use = text.find('Removed externalProxy from inbound {tag}')
+        assert assign != -1 and use != -1
+        assert assign < use
+        # idempotent
+        assert patch_xui_converter_tag_bug(tool) is False
+
+
+def test_assert_migrated_core_config_rejects_empty():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "db.sqlite3"
+        _make_pg_sqlite(path, users=1, inbounds=1, core_configs=0)
+        try:
+            assert_migrated_core_config(path)
+            raise AssertionError("expected empty core_configs error")
+        except RuntimeError as e:
+            assert "core_configs" in str(e)
+
+
+def test_run_cmd_shell_string_uses_subprocess_shell():
+    """Regression: db_auth MySQL probe passes shell strings; must not char-split exec."""
+    async def _run():
+        job = MigrationJob(job_id="shell1")
+        migrator = XuiMigrator(job, {})
+
+        class FakeProc:
+            returncode = 0
+            stdout = None
+
+            def __init__(self):
+                self._done = False
+
+            async def wait(self):
+                return 0
+
+            def kill(self):
+                pass
+
+        calls = {"shell": 0, "exec": 0}
+
+        async def fake_shell(cmd, **kwargs):
+            calls["shell"] += 1
+            assert isinstance(cmd, str)
+            assert "docker compose exec" in cmd
+            proc = FakeProc()
+
+            class Out:
+                async def readline(self):
+                    return b""
+
+            proc.stdout = Out()
+            return proc
+
+        async def fake_exec(*args, **kwargs):
+            calls["exec"] += 1
+            raise AssertionError("shell string must not use create_subprocess_exec")
+
+        with patch("asyncio.create_subprocess_shell", fake_shell), \
+             patch("asyncio.create_subprocess_exec", fake_exec):
+            ok, _ = await migrator._run_cmd(
+                'cd "/opt/pasarguard" && docker compose exec -T mysql mysql -u root -p"x" -N -e "SELECT 1"',
+                timeout=5,
+            )
+        assert ok
+        assert calls["shell"] == 1
+        assert calls["exec"] == 0
+        # Must not log character-spaced command
+        assert not any("$ c d" in line for line in job.logs)
+
+    asyncio.run(_run())
+
+
 if __name__ == "__main__":
     test_find_xui_db_prefers_named_file()
     test_find_xui_db_fallback_any_db()
@@ -405,4 +514,7 @@ if __name__ == "__main__":
     test_assert_migrated_pg_has_data()
     test_run_does_not_copy2_directory()
     test_run_uses_bundled_schema_not_mysql_start()
+    test_patch_xui_converter_tag_bug_moves_assignment()
+    test_assert_migrated_core_config_rejects_empty()
+    test_run_cmd_shell_string_uses_subprocess_shell()
     print("\nAll x-ui migrator tests passed.")


### PR DESCRIPTION
## Summary
- Fix BaseMigrator `_run_cmd` to run `db_auth` shell probes via `create_subprocess_shell` (was char-splitting strings → FileNotFoundError on sqlite→MySQL)
- Patch upstream x-ui converter `tag` UnboundLocalError before migrate.py so `core_configs` is created when inbounds have externalProxy/security
- Fail hard if core_configs is still empty after official migration

## Test plan
- [x] pytest tests/test_xui_migrator.py tests/test_db_auth.py (shell probe + tag patch regressions)
- [x] Official migrate.py on sample x-ui.db → core_configs: 1 migrated
- [ ] Re-run 3x-ui → MySQL migration on server after deploy

Made with [Cursor](https://cursor.com)