### PR TITLE
Fix Failed to create ephemeral MySQL database on MariaDB→Timescale migrate

### DIFF
--- a/app/services/migrators/marzban.py
+++ b/app/services/migrators/marzban.py
@@ -627,10 +627,16 @@ class MarzbanMigrator(BaseMigrator):
         svc = resolve_db_service("mysql") or resolve_db_service("mariadb") or "mysql"
         await self._run_cmd(["docker", "compose", "up", "-d", svc], cwd=str(PASARGUARD_DIR))
         await asyncio.sleep(6)
+        from app.services.native_migration.sql_staging import (
+            mysql_create_db_sql,
+            mysql_shell_e_arg,
+        )
+
+        # Single-quote -e SQL: double quotes expand backticks via command substitution
+        e_sql = mysql_shell_e_arg(mysql_create_db_sql(db, drop_first=True))
         wipe = await asyncio.create_subprocess_shell(
             f'cd "{PASARGUARD_DIR}" && docker compose exec -T {svc} '
-            f'mysql -u {user} -p"{pwd}" -h {host} -e '
-            f'"DROP DATABASE IF EXISTS `{db}`; CREATE DATABASE `{db}`; "'
+            f'mysql -u {user} -p"{pwd}" -h {host} -e {e_sql}'
         )
         await wipe.wait()
         proc = await asyncio.create_subprocess_shell(

--- a/app/services/native_migration/cross_db.py
+++ b/app/services/native_migration/cross_db.py
@@ -134,13 +134,18 @@ async def _reset_target_schema(migrator, target_db: str) -> None:
         ]
     else:
         from app.services.pasarguard_ops import mysql_client_bins
+        from app.services.native_migration.sql_staging import (
+            mysql_create_db_sql,
+            mysql_shell_e_arg,
+        )
 
         pwd_q = (pwd or "").replace('"', '\\"')
+        # Single-quote -e SQL: double quotes expand backticks via command substitution
+        e_sql = mysql_shell_e_arg(mysql_create_db_sql(db, drop_first=True))
         cmds = [
             (
                 f'cd "{cwd}" && docker compose exec -T {service} '
-                f'{bin_name} -u {user} -p"{pwd_q}" -e '
-                f'"DROP DATABASE IF EXISTS `{db}`; CREATE DATABASE `{db}`;"'
+                f'{bin_name} -u {user} -p"{pwd_q}" -e {e_sql}'
             )
             for bin_name in mysql_client_bins(target_db, service)
         ]

--- a/app/services/native_migration/sql_staging.py
+++ b/app/services/native_migration/sql_staging.py
@@ -187,6 +187,25 @@ async def _import_via_compose_service(
         await p.wait()
 
 
+def mysql_create_db_sql(db: str, *, drop_first: bool = False) -> str:
+    """Build CREATE DATABASE SQL with backticks (safe when not shell-double-quoted)."""
+    safe = _safe_mysql_ident(db)
+    if drop_first:
+        return f"DROP DATABASE IF EXISTS `{safe}`; CREATE DATABASE `{safe}`;"
+    return f"CREATE DATABASE `{safe}`;"
+
+
+def _ephemeral_mysql_runtime(source_db: str) -> tuple[str, str, str]:
+    """Pick image + client binaries that can load the source dump.
+
+    MariaDB 11 dumps use collations (e.g. utf8mb4_uca1400_ai_ci) that MySQL 8
+    rejects — staging must use mariadb:11 for mariadb sources.
+    """
+    if (source_db or "").lower() == "mariadb":
+        return "mariadb:11", "mariadb", "mariadb-admin"
+    return "mysql:8", "mysql", "mysqladmin"
+
+
 async def _mysql_ephemeral(
     container: str,
     pwd: str,
@@ -194,8 +213,9 @@ async def _mysql_ephemeral(
     sql: str | None = None,
     database: str | None = None,
     stdin_path: Path | None = None,
+    client: str = "mysql",
 ) -> tuple[int, str]:
-    """Run mysql via docker exec argv (never through a shell).
+    """Run mysql/mariadb via docker exec argv (never through a shell).
 
     Shell -e with double-quoted ``CREATE DATABASE `name`;`` expands backticks
     via command substitution and yields ``CREATE DATABASE ;``.
@@ -204,7 +224,7 @@ async def _mysql_ephemeral(
         "docker", "exec",
         *(["-i"] if stdin_path is not None else []),
         container,
-        "mysql", "-h", "127.0.0.1", "-u", "root", f"-p{pwd}",
+        client, "-h", "127.0.0.1", "-u", "root", f"-p{pwd}",
     ]
     if database:
         base.append(database)
@@ -227,8 +247,15 @@ async def _mysql_ephemeral(
     return proc.returncode or 0, (out_b or b"").decode("utf-8", errors="replace")
 
 
-async def _wait_ephemeral_mysql_ready(container: str, pwd: str, attempts: int = 90) -> None:
-    """Wait until MySQL accepts queries (not just mysqladmin ping during init)."""
+async def _wait_ephemeral_mysql_ready(
+    container: str,
+    pwd: str,
+    attempts: int = 90,
+    *,
+    client: str = "mysql",
+    admin_client: str = "mysqladmin",
+) -> None:
+    """Wait until MySQL/MariaDB accepts queries (not just admin ping during init)."""
     last = ""
     streak = 0
     need_streak = 3  # ~6s of continuous readiness at 2s interval
@@ -240,13 +267,15 @@ async def _wait_ephemeral_mysql_ready(container: str, pwd: str, attempts: int = 
             )
         proc = await asyncio.create_subprocess_exec(
             "docker", "exec", container,
-            "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", f"-p{pwd}", "--silent",
+            admin_client, "ping", "-h", "127.0.0.1", "-uroot", f"-p{pwd}", "--silent",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
         out_b, _ = await proc.communicate()
         if proc.returncode == 0:
-            rc, out = await _mysql_ephemeral(container, pwd, sql="SELECT 1;")
+            rc, out = await _mysql_ephemeral(
+                container, pwd, sql="SELECT 1;", client=client,
+            )
             if rc == 0:
                 streak += 1
                 if streak >= need_streak:
@@ -266,40 +295,53 @@ async def _wait_ephemeral_mysql_ready(container: str, pwd: str, attempts: int = 
 
 
 async def _import_via_ephemeral_mysql(
-    migrator, dump_path: Path, conn: dict, staging_db: str, container: str,
+    migrator,
+    dump_path: Path,
+    conn: dict,
+    staging_db: str,
+    container: str,
+    source_db: str = "mysql",
 ) -> dict:
     pwd = "pgmigrator"
     user = "root"
     port = _pick_free_host_port(33060)
     safe_db = _safe_mysql_ident(staging_db)
+    image, client, admin_client = _ephemeral_mysql_runtime(source_db)
 
     await migrator._run_cmd(["docker", "rm", "-f", container], timeout=30)
+    migrator.job.log(
+        f"Staging {source_db} dump into ephemeral container ({image}, host port {port})..."
+    )
     ok, out = await migrator._run_cmd([
         "docker", "run", "-d", "--name", container,
         "-e", f"MYSQL_ROOT_PASSWORD={pwd}",
         "-p", f"127.0.0.1:{port}:3306",
-        "mysql:8",
+        image,
     ], timeout=180)
     if not ok:
-        raise RuntimeError(f"Failed to start ephemeral MySQL: {out[-500:]}")
+        raise RuntimeError(f"Failed to start ephemeral MySQL/MariaDB ({image}): {out[-500:]}")
 
     try:
-        migrator.job.log("Waiting for ephemeral MySQL to finish init...")
-        await _wait_ephemeral_mysql_ready(container, pwd)
+        migrator.job.log(f"Waiting for ephemeral {image} to finish init...")
+        await _wait_ephemeral_mysql_ready(
+            container, pwd, client=client, admin_client=admin_client,
+        )
 
         create_sql = mysql_create_db_sql(safe_db)
-        rc, create_out = await _mysql_ephemeral(container, pwd, sql=create_sql)
+        rc, create_out = await _mysql_ephemeral(
+            container, pwd, sql=create_sql, client=client,
+        )
         if rc != 0:
             raise RuntimeError(
                 f"Failed to create ephemeral MySQL database {safe_db}: {create_out[-500:]}"
             )
 
         rc, import_out = await _mysql_ephemeral(
-            container, pwd, database=safe_db, stdin_path=dump_path,
+            container, pwd, database=safe_db, stdin_path=dump_path, client=client,
         )
         if rc != 0:
             raise RuntimeError(
-                f"Failed to import MySQL dump into ephemeral container: {import_out[-500:]}"
+                f"Failed to import {source_db} dump into ephemeral {image}: {import_out[-500:]}"
             )
     except Exception as e:
         migrator.job.log(f"Ephemeral MySQL staging failed — cleaning up ({e})")
@@ -319,6 +361,7 @@ async def _import_via_ephemeral_mysql(
         "user": user,
         "password": pwd,
         "_ephemeral_container": container,
+        "_ephemeral_image": image,
     }
 
 
@@ -729,8 +772,13 @@ async def import_sql_dump_to_live_db(
                 "password": conn.get("password") or "",
             }
         container = f"pgmig-mysql-{uuid.uuid4().hex[:6]}"
-        migrator.job.log("Staging SQL dump into ephemeral MySQL container...")
-        return await _import_via_ephemeral_mysql(migrator, path, conn, staging_db, container)
+        migrator.job.log(
+            f"Staging {source_db} SQL dump into ephemeral container "
+            f"(no {source_db} compose service — Timescale/PG target path)..."
+        )
+        return await _import_via_ephemeral_mysql(
+            migrator, path, conn, staging_db, container, source_db,
+        )
 
     # ── Plain PostgreSQL source dumps ───────────────────────────────────
     if source_db == "postgresql":

--- a/app/services/native_migration/sql_staging.py
+++ b/app/services/native_migration/sql_staging.py
@@ -28,6 +28,34 @@ def _compose_has_service(name: str) -> bool:
     return bool(name and re.search(rf"^\s*{re.escape(name)}\s*:", text, re.MULTILINE))
 
 
+def _safe_mysql_ident(name: str) -> str:
+    """Validate a MySQL identifier (alphanumeric + underscore only)."""
+    safe = "".join(c for c in (name or "") if c.isalnum() or c == "_")
+    if safe != name or not safe:
+        raise RuntimeError(f"Invalid MySQL database name: {name}")
+    return safe
+
+
+def mysql_shell_e_arg(sql: str) -> str:
+    """Embed SQL in a shell -e argument safely.
+
+    Must use single quotes: double-quoted shell strings expand backticks as
+    command substitution, turning ``CREATE DATABASE `pgmig_abc`;`` into
+    ``CREATE DATABASE ;`` and breaking ephemeral/compose MySQL staging.
+    """
+    if "'" in sql:
+        raise RuntimeError("MySQL -e SQL must not contain single quotes")
+    return f"'{sql}'"
+
+
+def mysql_create_db_sql(db: str, *, drop_first: bool = False) -> str:
+    """Build CREATE DATABASE SQL with backticks (safe when not shell-double-quoted)."""
+    safe = _safe_mysql_ident(db)
+    if drop_first:
+        return f"DROP DATABASE IF EXISTS `{safe}`; CREATE DATABASE `{safe}`;"
+    return f"CREATE DATABASE `{safe}`;"
+
+
 async def _import_via_compose_service(
     migrator, dump_path: Path, source_db: str, service: str, conn: dict, staging_db: str,
 ) -> None:
@@ -38,20 +66,29 @@ async def _import_via_compose_service(
     cwd = str(PASARGUARD_DIR)
 
     if source_db in ("mysql", "mariadb"):
+        # Single-quote -e payload — backticks inside double quotes are eaten by the shell
+        e_sql = mysql_shell_e_arg(mysql_create_db_sql(staging_db, drop_first=True))
         create_cmd = (
             f'cd "{cwd}" && docker compose exec -T {service} '
-            f'mysql -u {user} -p"{pwd}" -e '
-            f'"DROP DATABASE IF EXISTS `{staging_db}`; CREATE DATABASE `{staging_db}`;"'
+            f'mysql -u {user} -p"{pwd}" -e {e_sql}'
         )
+        safe_db = _safe_mysql_ident(staging_db)
         import_cmd = (
             f'cd "{cwd}" && docker compose exec -T {service} '
-            f'mysql -u {user} -p"{pwd}" {staging_db} < "{dump_path}"'
+            f'mysql -u {user} -p"{pwd}" {safe_db} < "{dump_path}"'
         )
         for cmd in (create_cmd, import_cmd):
-            proc = await asyncio.create_subprocess_shell(cmd)
-            await proc.wait()
+            proc = await asyncio.create_subprocess_shell(
+                cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out_b, _ = await proc.communicate()
             if proc.returncode != 0:
-                raise RuntimeError(f"SQL staging failed (db={staging_db})")
+                out = (out_b or b"").decode("utf-8", errors="replace")
+                raise RuntimeError(
+                    f"SQL staging failed (db={staging_db}): {out[-400:]}"
+                )
         return
 
     # PostgreSQL / TimescaleDB via compose
@@ -150,28 +187,56 @@ async def _import_via_compose_service(
         await p.wait()
 
 
-async def _import_via_ephemeral_mysql(
-    migrator, dump_path: Path, conn: dict, staging_db: str, container: str,
-) -> dict:
-    pwd = "pgmigrator"
-    user = "root"
-    port = _pick_free_host_port(33060)
+async def _mysql_ephemeral(
+    container: str,
+    pwd: str,
+    *,
+    sql: str | None = None,
+    database: str | None = None,
+    stdin_path: Path | None = None,
+) -> tuple[int, str]:
+    """Run mysql via docker exec argv (never through a shell).
 
-    await migrator._run_cmd(["docker", "rm", "-f", container], timeout=30)
-    await migrator._run_cmd([
-        "docker", "run", "-d", "--name", container,
-        "-e", f"MYSQL_ROOT_PASSWORD={pwd}",
-        "-p", f"127.0.0.1:{port}:3306",
-        "mysql:8",
-    ], timeout=180)
+    Shell -e with double-quoted ``CREATE DATABASE `name`;`` expands backticks
+    via command substitution and yields ``CREATE DATABASE ;``.
+    """
+    base = [
+        "docker", "exec",
+        *(["-i"] if stdin_path is not None else []),
+        container,
+        "mysql", "-h", "127.0.0.1", "-u", "root", f"-p{pwd}",
+    ]
+    if database:
+        base.append(database)
+    if stdin_path is not None:
+        with open(stdin_path, "rb") as fh:
+            proc = await asyncio.create_subprocess_exec(
+                *base,
+                stdin=fh,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out_b, _ = await proc.communicate()
+            return proc.returncode or 0, (out_b or b"").decode("utf-8", errors="replace")
+    proc = await asyncio.create_subprocess_exec(
+        *base, "-e", sql or "SELECT 1",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    out_b, _ = await proc.communicate()
+    return proc.returncode or 0, (out_b or b"").decode("utf-8", errors="replace")
 
-    # Wait until mysql accepts connections (init can take a while)
-    ready = False
+
+async def _wait_ephemeral_mysql_ready(container: str, pwd: str, attempts: int = 90) -> None:
+    """Wait until MySQL accepts queries (not just mysqladmin ping during init)."""
     last = ""
-    for i in range(60):
+    streak = 0
+    need_streak = 3  # ~6s of continuous readiness at 2s interval
+    for _ in range(attempts):
         if not await _container_running(container):
+            logs = await _container_logs_tail(container)
             raise RuntimeError(
-                f"Ephemeral MySQL exited early:\n{(await _container_logs_tail(container))[-800:]}"
+                f"Ephemeral MySQL container {container} exited early:\n{logs[-1000:]}"
             )
         proc = await asyncio.create_subprocess_exec(
             "docker", "exec", container,
@@ -180,40 +245,77 @@ async def _import_via_ephemeral_mysql(
             stderr=asyncio.subprocess.STDOUT,
         )
         out_b, _ = await proc.communicate()
-        last = (out_b or b"").decode("utf-8", errors="replace")
         if proc.returncode == 0:
-            ready = True
-            break
+            rc, out = await _mysql_ephemeral(container, pwd, sql="SELECT 1;")
+            if rc == 0:
+                streak += 1
+                if streak >= need_streak:
+                    return
+            else:
+                streak = 0
+                last = out or (out_b or b"").decode("utf-8", errors="replace")
+        else:
+            streak = 0
+            last = (out_b or b"").decode("utf-8", errors="replace")
         await asyncio.sleep(2)
-    if not ready:
-        await migrator._run_cmd(["docker", "rm", "-f", container], timeout=30)
-        raise RuntimeError(f"Ephemeral MySQL did not become ready: {last[-300:]}")
-
-    init_cmd = (
-        f'docker exec -i {container} mysql -h127.0.0.1 -u root -p"{pwd}" -e '
-        f'"CREATE DATABASE `{staging_db}`;"'
+    logs = await _container_logs_tail(container)
+    raise RuntimeError(
+        f"Ephemeral MySQL container {container} did not become ready: {last[-400:]}\n"
+        f"--- docker logs ---\n{logs[-800:]}"
     )
-    proc = await asyncio.create_subprocess_shell(init_cmd)
-    await proc.wait()
-    if proc.returncode != 0:
-        await migrator._run_cmd(["docker", "rm", "-f", container], timeout=30)
-        raise RuntimeError(f"Failed to create ephemeral MySQL database {staging_db}")
 
-    with open(dump_path, "rb") as fh:
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "exec", "-i", container,
-            "mysql", "-h127.0.0.1", "-u", "root", f"-p{pwd}", staging_db,
-            stdin=fh,
+
+async def _import_via_ephemeral_mysql(
+    migrator, dump_path: Path, conn: dict, staging_db: str, container: str,
+) -> dict:
+    pwd = "pgmigrator"
+    user = "root"
+    port = _pick_free_host_port(33060)
+    safe_db = _safe_mysql_ident(staging_db)
+
+    await migrator._run_cmd(["docker", "rm", "-f", container], timeout=30)
+    ok, out = await migrator._run_cmd([
+        "docker", "run", "-d", "--name", container,
+        "-e", f"MYSQL_ROOT_PASSWORD={pwd}",
+        "-p", f"127.0.0.1:{port}:3306",
+        "mysql:8",
+    ], timeout=180)
+    if not ok:
+        raise RuntimeError(f"Failed to start ephemeral MySQL: {out[-500:]}")
+
+    try:
+        migrator.job.log("Waiting for ephemeral MySQL to finish init...")
+        await _wait_ephemeral_mysql_ready(container, pwd)
+
+        create_sql = mysql_create_db_sql(safe_db)
+        rc, create_out = await _mysql_ephemeral(container, pwd, sql=create_sql)
+        if rc != 0:
+            raise RuntimeError(
+                f"Failed to create ephemeral MySQL database {safe_db}: {create_out[-500:]}"
+            )
+
+        rc, import_out = await _mysql_ephemeral(
+            container, pwd, database=safe_db, stdin_path=dump_path,
         )
-        await proc.wait()
-        if proc.returncode != 0:
-            await migrator._run_cmd(["docker", "rm", "-f", container], timeout=30)
-            raise RuntimeError("Failed to import MySQL dump into ephemeral container")
+        if rc != 0:
+            raise RuntimeError(
+                f"Failed to import MySQL dump into ephemeral container: {import_out[-500:]}"
+            )
+    except Exception as e:
+        migrator.job.log(f"Ephemeral MySQL staging failed — cleaning up ({e})")
+        try:
+            logs = await _container_logs_tail(container)
+            if logs.strip():
+                migrator.job.log(f"Ephemeral MySQL logs:\n{logs[-1200:]}")
+        except Exception:
+            pass
+        await migrator._run_cmd(["docker", "rm", "-f", container], timeout=30)
+        raise
 
     return {
         "host": "127.0.0.1",
         "port": port,
-        "database": staging_db,
+        "database": safe_db,
         "user": user,
         "password": pwd,
         "_ephemeral_container": container,

--- a/app/services/pasarguard_ops.py
+++ b/app/services/pasarguard_ops.py
@@ -478,11 +478,19 @@ async def read_mysql_alembic_version(migrator, target_db: str) -> str | None:
     db = conn.get("database") or "pasarguard"
     cwd = str(PASARGUARD_DIR)
     pwd_q = (pwd or "").replace('"', '\\"')
+    from app.services.native_migration.sql_staging import (
+        _safe_mysql_ident,
+        mysql_shell_e_arg,
+    )
+
+    safe_db = _safe_mysql_ident(db)
+    e_sql = mysql_shell_e_arg(
+        f"SELECT version_num FROM `{safe_db}`.alembic_version LIMIT 1"
+    )
     for bin_name in mysql_client_bins(target_db, service):
         cmd = (
             f'cd "{cwd}" && docker compose exec -T {service} '
-            f'{bin_name} -u {user} -p"{pwd_q}" -h {host} -N -e '
-            f'"SELECT version_num FROM `{db}`.alembic_version LIMIT 1"'
+            f'{bin_name} -u {user} -p"{pwd_q}" -h {host} -N -e {e_sql}'
         )
         proc = await asyncio.create_subprocess_shell(
             cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
@@ -653,12 +661,19 @@ async def read_target_alembic_version(migrator, target_db: str) -> str | None:
         host = conn.get("host") or "127.0.0.1"
         pwd_q = (pwd or "").replace('"', '\\"')
         from app.services.native_migration.source_version import normalize_alembic_revision
+        from app.services.native_migration.sql_staging import (
+            _safe_mysql_ident,
+            mysql_shell_e_arg,
+        )
 
+        safe_db = _safe_mysql_ident(db)
+        e_sql = mysql_shell_e_arg(
+            f"SELECT version_num FROM `{safe_db}`.alembic_version LIMIT 1"
+        )
         for bin_name in mysql_client_bins(target_db, service):
             cmd = (
                 f'cd "{cwd}" && docker compose exec -T {service} '
-                f'{bin_name} -u {user} -p"{pwd_q}" -h {host} -N -e '
-                f'"SELECT version_num FROM `{db}`.alembic_version LIMIT 1"'
+                f'{bin_name} -u {user} -p"{pwd_q}" -h {host} -N -e {e_sql}'
             )
             proc = await asyncio.create_subprocess_shell(
                 cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,

--- a/tests/integration_cross_db.py
+++ b/tests/integration_cross_db.py
@@ -327,6 +327,399 @@ def test_mysql_to_postgres_full_schema():
         subprocess.run(["docker", "rm", "-f", my_name], capture_output=True)
 
 
+def _timescale_run_args(name: str, port: int) -> list[str]:
+    """Start Timescale; skip timescaledb-tune (panics without cgroup memory)."""
+    return [
+        "docker", "run", "-d", "--name", name,
+        "-e", "POSTGRES_PASSWORD=test",
+        "-e", "POSTGRES_USER=postgres",
+        "-e", "POSTGRES_DB=pasarguard",
+        "-p", f"127.0.0.1:{port}:5432",
+        "-v", "/dev/null:/docker-entrypoint-initdb.d/001_timescaledb_tune.sh:ro",
+        "timescale/timescaledb:latest-pg16",
+    ]
+
+
+def _wait_mysql_ready(port: int, password: str = "test", database: str = "pasarguard", timeout: float = 120):
+    import pymysql
+
+    _wait_port("127.0.0.1", port, timeout=timeout)
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        try:
+            conn = pymysql.connect(
+                host="127.0.0.1", port=port, user="root",
+                password=password, database=database,
+            )
+            conn.close()
+            return
+        except Exception as exc:
+            last = exc
+            time.sleep(2)
+    raise RuntimeError(f"MySQL/MariaDB not ready on {port}: {last}")
+
+
+def _wait_pg_ready(port: int, user: str = "postgres", password: str = "test",
+                   database: str = "pasarguard", timeout: float = 120):
+    import psycopg2
+
+    _wait_port("127.0.0.1", port, timeout=timeout)
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        try:
+            conn = psycopg2.connect(
+                host="127.0.0.1", port=port, dbname=database,
+                user=user, password=password,
+            )
+            conn.close()
+            return
+        except Exception as exc:
+            last = exc
+            time.sleep(2)
+    raise RuntimeError(f"Postgres/Timescale not ready on {port}: {last}")
+
+
+def _mariadb_seed_full(port: int) -> None:
+    import pymysql
+
+    conn = pymysql.connect(
+        host="127.0.0.1", port=port, user="root",
+        password="test", database="pasarguard",
+    )
+    cur = conn.cursor()
+    _create_mysql_full_schema(cur)
+    cur.execute("INSERT INTO admins VALUES (1, 'admin', 1)")
+    cur.execute("INSERT INTO core_configs VALUES (1, 'xray')")
+    cur.execute(
+        "INSERT INTO nodes VALUES (1, 'n1', '1.2.3.4', 1, '', '', 'healthy')"
+    )
+    cur.execute("INSERT INTO inbounds VALUES (1, 'vless-tcp', 'vless', 0)")
+    cur.execute("INSERT INTO groups VALUES (1, 'default', 0)")
+    cur.execute(
+        "INSERT INTO hosts VALUES (1, 'h1', 'vless-tcp', NULL, NULL, "
+        "'{\"enabled\": true}', 0, 'none', 'none')"
+    )
+    cur.execute("INSERT INTO users VALUES (1, 'u1', 'active', 1, 1)")
+    cur.execute("INSERT INTO users VALUES (2, 'u2', 'active', 1, 1)")
+    cur.execute("INSERT INTO alembic_version VALUES ('deadbeefcafe')")
+    conn.commit()
+    conn.close()
+
+
+def _timescale_prepare_schema(port: int) -> None:
+    import psycopg2
+
+    conn = psycopg2.connect(
+        host="127.0.0.1", port=port, dbname="pasarguard",
+        user="postgres", password="test",
+    )
+    cur = conn.cursor()
+    cur.execute("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;")
+    _create_pg_full_schema(cur)
+    conn.commit()
+    conn.close()
+
+
+def test_ephemeral_mysql_create_database_real_docker():
+    """Regression for reported failure: CREATE DATABASE on ephemeral mysql:8.
+
+    Exact user path: MariaDB dump + Timescale-only compose → ephemeral MySQL staging.
+    """
+    import asyncio
+    import pymysql
+    from app.services.native_migration import sql_staging as mod
+
+    dump = Path(tempfile.mkstemp(suffix=".sql")[1])
+    dump.write_text(
+        "CREATE TABLE users (id INT PRIMARY KEY, username VARCHAR(64));\n"
+        "INSERT INTO users VALUES (1, 'from_mariadb_dump');\n"
+        "CREATE TABLE admins (id INT PRIMARY KEY, username VARCHAR(64), is_sudo TINYINT);\n"
+        "INSERT INTO admins VALUES (1, 'admin', 1);\n",
+        encoding="utf-8",
+    )
+    container = None  # filled after import
+    logs: list[str] = []
+    result = None
+
+    class Job:
+        def log(self, msg, *_a, **_k):
+            logs.append(str(msg))
+
+    class Mini:
+        def __init__(self):
+            self.job = Job()
+
+        async def _run_cmd(self, cmd, timeout=60, cwd=None):
+            try:
+                r = subprocess.run(
+                    cmd, capture_output=True, timeout=timeout, cwd=cwd,
+                )
+                out = (r.stdout or b"").decode() + (r.stderr or b"").decode()
+                return r.returncode == 0, out
+            except Exception as exc:
+                return False, str(exc)
+
+    # Simulate Timescale-only compose (no mysql/mariadb service)
+    orig_compose = mod._compose_text
+    orig_resolve = mod.resolve_db_service
+    mod._compose_text = lambda: (
+        "services:\n  timescaledb:\n    image: timescale/timescaledb:latest-pg16\n"
+    )
+    mod.resolve_db_service = lambda db: "timescaledb" if db == "timescaledb" else None
+
+    try:
+        result = asyncio.run(
+            mod.import_sql_dump_to_live_db(
+                Mini(), str(dump), "mariadb", {"password": "x"},
+            )
+        )
+        assert result.get("_ephemeral_container"), result
+        assert result["database"].startswith("pgmig_"), result
+        container = result["_ephemeral_container"]
+        # Prove CREATE DATABASE + dump import actually landed
+        conn = pymysql.connect(
+            host=result["host"],
+            port=int(result["port"]),
+            user=result["user"],
+            password=result["password"],
+            database=result["database"],
+        )
+        cur = conn.cursor()
+        cur.execute("SELECT username FROM users WHERE id=1")
+        assert cur.fetchone()[0] == "from_mariadb_dump"
+        cur.execute("SELECT COUNT(*) FROM admins")
+        assert cur.fetchone()[0] == 1
+        conn.close()
+        print("OK: ephemeral MySQL CREATE DATABASE + dump import (MariaDB→Timescale path)")
+    finally:
+        mod._compose_text = orig_compose
+        mod.resolve_db_service = orig_resolve
+        dump.unlink(missing_ok=True)
+        if container:
+            subprocess.run(["docker", "rm", "-f", container], capture_output=True)
+        out = subprocess.run(
+            ["docker", "ps", "-aq", "--filter", "name=pgmig-mysql-"],
+            capture_output=True, text=True,
+        )
+        for cid in (out.stdout or "").split():
+            subprocess.run(["docker", "rm", "-f", cid], capture_output=True)
+
+
+def test_mariadb_to_timescaledb_full_schema():
+    """Live MariaDB → TimescaleDB universal copy with row verification."""
+    import psycopg2
+    import pymysql
+
+    maria_name = f"pgmig-maria-{uuid.uuid4().hex[:8]}"
+    ts_name = f"pgmig-ts-{uuid.uuid4().hex[:8]}"
+    maria_port, ts_port = 33190, 55490
+
+    subprocess.run(
+        [
+            "docker", "run", "-d", "--name", maria_name,
+            "-e", "MYSQL_ROOT_PASSWORD=test",
+            "-e", "MYSQL_DATABASE=pasarguard",
+            "-p", f"127.0.0.1:{maria_port}:3306",
+            "mariadb:11",
+        ],
+        check=True, capture_output=True,
+    )
+    subprocess.run(_timescale_run_args(ts_name, ts_port), check=True, capture_output=True)
+
+    try:
+        _wait_mysql_ready(maria_port)
+        _wait_pg_ready(ts_port)
+        _mariadb_seed_full(maria_port)
+        _timescale_prepare_schema(ts_port)
+
+        from app.services.native_migration.adapters import (
+            create_reader, create_writer, copy_tables_universal,
+        )
+        src = {
+            "host": "127.0.0.1", "port": str(maria_port),
+            "database": "pasarguard", "user": "root", "password": "test",
+        }
+        dst = {
+            "host": "127.0.0.1", "port": str(ts_port),
+            "database": "pasarguard", "user": "postgres", "password": "test",
+        }
+        reader = create_reader("mariadb", None, src)
+        writer = create_writer("timescaledb", dst)
+        try:
+            stats, _ = copy_tables_universal(
+                reader, writer, lambda _m: None, fail_hard=True,
+            )
+        finally:
+            reader.close()
+            writer.close()
+
+        for tbl in ("users", "hosts", "nodes", "inbounds", "groups", "admins"):
+            assert stats.get(tbl, 0) >= 1, f"{tbl}: {stats}"
+        assert stats.get("users") == 2, stats
+
+        # Verify actual Timescale rows + extension
+        conn = psycopg2.connect(
+            host="127.0.0.1", port=ts_port, dbname="pasarguard",
+            user="postgres", password="test",
+        )
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM users")
+        assert cur.fetchone()[0] == 2
+        cur.execute("SELECT username FROM users ORDER BY id")
+        assert [r[0] for r in cur.fetchall()] == ["u1", "u2"]
+        cur.execute("SELECT is_sudo FROM admins WHERE id=1")
+        assert cur.fetchone()[0] is True
+        cur.execute("SELECT extname FROM pg_extension WHERE extname='timescaledb'")
+        assert cur.fetchone()[0] == "timescaledb"
+        conn.close()
+        print("OK: mariadb → timescaledb (full schema + row verify)")
+    finally:
+        subprocess.run(["docker", "rm", "-f", maria_name], capture_output=True)
+        subprocess.run(["docker", "rm", "-f", ts_name], capture_output=True)
+
+
+def test_mariadb_dump_ephemeral_then_timescaledb():
+    """End-to-end like the panel convert: MariaDB .sql → ephemeral MySQL → Timescale."""
+    import asyncio
+    import pymysql
+    import psycopg2
+    from app.services.native_migration import sql_staging as mod
+    from app.services.native_migration.adapters import (
+        create_reader, create_writer, copy_tables_universal,
+    )
+
+    maria_name = f"pgmig-mdump-{uuid.uuid4().hex[:8]}"
+    ts_name = f"pgmig-tsdump-{uuid.uuid4().hex[:8]}"
+    maria_port, ts_port = 33191, 55491
+
+    subprocess.run(
+        [
+            "docker", "run", "-d", "--name", maria_name,
+            "-e", "MYSQL_ROOT_PASSWORD=test",
+            "-e", "MYSQL_DATABASE=pasarguard",
+            "-p", f"127.0.0.1:{maria_port}:3306",
+            "mariadb:11",
+        ],
+        check=True, capture_output=True,
+    )
+    subprocess.run(_timescale_run_args(ts_name, ts_port), check=True, capture_output=True)
+
+    dump = Path(tempfile.mkstemp(suffix="-mariadb.sql")[1])
+    staging_container = None
+    try:
+        _wait_mysql_ready(maria_port)
+        _wait_pg_ready(ts_port)
+        _mariadb_seed_full(maria_port)
+        _timescale_prepare_schema(ts_port)
+
+        # mysqldump-style dump from live MariaDB (what backup restore uses)
+        with open(dump, "wb") as fh:
+            r = subprocess.run(
+                [
+                    "docker", "exec", maria_name,
+                    "mariadb-dump", "-uroot", "-ptest", "pasarguard",
+                ],
+                stdout=fh, stderr=subprocess.PIPE, check=True,
+            )
+        assert dump.stat().st_size > 100, "empty dump"
+
+        class Job:
+            def log(self, msg, *_a, **_k):
+                print(f"  [staging] {msg}")
+
+        class Mini:
+            def __init__(self):
+                self.job = Job()
+
+            async def _run_cmd(self, cmd, timeout=180, cwd=None):
+                try:
+                    rr = subprocess.run(
+                        cmd, capture_output=True, timeout=timeout, cwd=cwd,
+                    )
+                    out = (rr.stdout or b"").decode() + (rr.stderr or b"").decode()
+                    return rr.returncode == 0, out
+                except Exception as exc:
+                    return False, str(exc)
+
+        orig_compose = mod._compose_text
+        orig_resolve = mod.resolve_db_service
+        mod._compose_text = lambda: (
+            "services:\n  timescaledb:\n    image: timescale/timescaledb:latest-pg16\n"
+        )
+        mod.resolve_db_service = lambda db: (
+            "timescaledb" if db == "timescaledb" else None
+        )
+        try:
+            staging = asyncio.run(
+                mod.import_sql_dump_to_live_db(
+                    Mini(), str(dump), "mariadb", {"password": "x"},
+                )
+            )
+        finally:
+            mod._compose_text = orig_compose
+            mod.resolve_db_service = orig_resolve
+
+        staging_container = staging.get("_ephemeral_container")
+        assert staging_container, staging
+
+        # Prove staging has MariaDB rows
+        sconn = pymysql.connect(
+            host=staging["host"], port=int(staging["port"]),
+            user=staging["user"], password=staging["password"],
+            database=staging["database"],
+        )
+        scur = sconn.cursor()
+        scur.execute("SELECT COUNT(*) FROM users")
+        assert scur.fetchone()[0] == 2
+        sconn.close()
+
+        dst = {
+            "host": "127.0.0.1", "port": str(ts_port),
+            "database": "pasarguard", "user": "postgres", "password": "test",
+        }
+        reader = create_reader("mariadb", None, staging)
+        writer = create_writer("timescaledb", dst)
+        try:
+            stats, _ = copy_tables_universal(
+                reader, writer, lambda _m: None, fail_hard=True,
+            )
+        finally:
+            reader.close()
+            writer.close()
+
+        assert stats.get("users") == 2, stats
+        assert stats.get("admins") == 1, stats
+
+        conn = psycopg2.connect(
+            host="127.0.0.1", port=ts_port, dbname="pasarguard",
+            user="postgres", password="test",
+        )
+        cur = conn.cursor()
+        cur.execute("SELECT username FROM users ORDER BY id")
+        assert [r[0] for r in cur.fetchall()] == ["u1", "u2"]
+        cur.execute("SELECT remark FROM hosts WHERE id=1")
+        assert cur.fetchone()[0] == "h1"
+        cur.execute("SELECT extname FROM pg_extension WHERE extname='timescaledb'")
+        assert cur.fetchone() is not None
+        conn.close()
+        print("OK: mariadb dump → ephemeral MySQL → timescaledb (E2E)")
+    finally:
+        dump.unlink(missing_ok=True)
+        if staging_container:
+            subprocess.run(["docker", "rm", "-f", staging_container], capture_output=True)
+        subprocess.run(["docker", "rm", "-f", maria_name], capture_output=True)
+        subprocess.run(["docker", "rm", "-f", ts_name], capture_output=True)
+        # Sweep any leftover ephemeral mysql from failed runs
+        out = subprocess.run(
+            ["docker", "ps", "-aq", "--filter", "name=pgmig-mysql-"],
+            capture_output=True, text=True,
+        )
+        for cid in (out.stdout or "").split():
+            subprocess.run(["docker", "rm", "-f", cid], capture_output=True)
+
+
 def _make_source_sqlite(path: Path) -> None:
     conn = sqlite3.connect(path)
     conn.executescript(
@@ -737,4 +1130,8 @@ if __name__ == "__main__":
     test_sqlite_to_mysql("mariadb:11", "mariadb")
     test_sqlite_to_mysql_full_schema("mariadb", "mariadb:11", 33074)
     test_mysql_to_postgres_full_schema()
+    # MariaDB → TimescaleDB (reported failure path)
+    test_ephemeral_mysql_create_database_real_docker()
+    test_mariadb_to_timescaledb_full_schema()
+    test_mariadb_dump_ephemeral_then_timescaledb()
     print("\nAll integration tests passed.")

--- a/tests/test_sql_staging.py
+++ b/tests/test_sql_staging.py
@@ -208,6 +208,203 @@ def test_transient_pg_error_detection():
     print("OK: transient pg error detection")
 
 
+def test_mysql_shell_e_arg_preserves_backticks():
+    """Regression: double-quoted -e ate backticks → CREATE DATABASE ;"""
+    import subprocess
+    from app.services.native_migration.sql_staging import (
+        mysql_create_db_sql,
+        mysql_shell_e_arg,
+    )
+
+    staging_db = "pgmig_89b78bab"
+    sql = mysql_create_db_sql(staging_db)
+    assert f"`{staging_db}`" in sql
+
+    # Buggy historical pattern (double quotes) expands backticks away
+    buggy = subprocess.run(
+        f'echo "CREATE DATABASE `{staging_db}`;"',
+        shell=True, capture_output=True, text=True,
+    )
+    assert "CREATE DATABASE ;" in buggy.stdout, buggy.stdout
+
+    # Fixed pattern (single quotes via helper) must keep identifier
+    fixed = subprocess.run(
+        f"echo {mysql_shell_e_arg(sql)}",
+        shell=True, capture_output=True, text=True,
+    )
+    assert f"`{staging_db}`" in fixed.stdout, fixed.stdout
+    assert "CREATE DATABASE ;" not in fixed.stdout
+    print("OK: mysql_shell_e_arg preserves backticks under shell")
+
+
+def test_mysql_create_db_sql_drop_first():
+    from app.services.native_migration.sql_staging import mysql_create_db_sql
+
+    s = mysql_create_db_sql("pgmig_abc123", drop_first=True)
+    assert "DROP DATABASE IF EXISTS `pgmig_abc123`" in s
+    assert "CREATE DATABASE `pgmig_abc123`" in s
+    try:
+        mysql_create_db_sql("evil;drop")
+        assert False, "expected invalid name"
+    except RuntimeError:
+        pass
+    print("OK: mysql_create_db_sql validates names")
+
+
+def test_mysql_ephemeral_create_uses_exec_not_shell():
+    """CREATE DATABASE must go through docker exec argv, never shell -e."""
+    import asyncio
+    from app.services.native_migration import sql_staging as mod
+
+    calls: list[tuple] = []
+
+    async def fake_mysql(container, pwd, *, sql=None, database=None, stdin_path=None):
+        calls.append({"sql": sql, "database": database, "stdin": stdin_path})
+        return 0, "ok"
+
+    async def fake_ready(container, pwd, attempts=90):
+        return None
+
+    class Job:
+        def log(self, *_a, **_k):
+            pass
+
+    class Mini:
+        def __init__(self):
+            self.job = Job()
+
+        async def _run_cmd(self, *a, **k):
+            return True, "cid"
+
+    tmp = Path("/tmp/pgmig_mysql_ephemeral_test.sql")
+    tmp.write_text("CREATE TABLE t (id int);\n", encoding="utf-8")
+
+    orig_mysql = mod._mysql_ephemeral
+    orig_ready = mod._wait_ephemeral_mysql_ready
+    mod._mysql_ephemeral = fake_mysql
+    mod._wait_ephemeral_mysql_ready = fake_ready
+    try:
+        result = asyncio.run(
+            mod._import_via_ephemeral_mysql(
+                Mini(), tmp, {}, "pgmig_89b78bab", "pgmig-mysql-test",
+            )
+        )
+        assert result["database"] == "pgmig_89b78bab"
+        assert result.get("_ephemeral_container") == "pgmig-mysql-test"
+        assert any(
+            c["sql"] and "CREATE DATABASE `pgmig_89b78bab`" in c["sql"]
+            for c in calls
+        ), calls
+        assert any(c["stdin"] == tmp for c in calls), calls
+        # Must not use shell-eaten empty CREATE DATABASE
+        assert not any(c["sql"] == "CREATE DATABASE ;" for c in calls)
+        print("OK: ephemeral MySQL create uses exec helper with intact backticks")
+    finally:
+        mod._mysql_ephemeral = orig_mysql
+        mod._wait_ephemeral_mysql_ready = orig_ready
+        tmp.unlink(missing_ok=True)
+
+
+def test_import_mysql_dump_routes_to_ephemeral_when_target_is_timescale():
+    """MariaDB/MySQL → Timescale: no mysql compose service → ephemeral MySQL."""
+    import asyncio
+    from app.services.native_migration import sql_staging as mod
+
+    calls = {"ephemeral": 0}
+
+    async def fake_ephemeral(migrator, dump_path, conn, staging_db, container):
+        calls["ephemeral"] += 1
+        assert staging_db.startswith("pgmig_")
+        assert container.startswith("pgmig-mysql-")
+        return {
+            "host": "127.0.0.1",
+            "port": "33060",
+            "database": staging_db,
+            "user": "root",
+            "password": "pgmigrator",
+            "_ephemeral_container": container,
+        }
+
+    class Job:
+        def log(self, *_a, **_k):
+            pass
+
+    class Mini:
+        def __init__(self):
+            self.job = Job()
+
+        async def _run_cmd(self, *a, **k):
+            return True, ""
+
+    orig_compose = mod._compose_text
+    orig_resolve = mod.resolve_db_service
+    orig_ephemeral = mod._import_via_ephemeral_mysql
+    # Live panel is Timescale only — matches reported MariaDB→Timescale migration
+    mod._compose_text = lambda: (
+        "services:\n  timescaledb:\n    image: timescale/timescaledb:latest-pg17\n"
+    )
+    mod.resolve_db_service = lambda db: "timescaledb" if db == "timescaledb" else None
+    mod._import_via_ephemeral_mysql = fake_ephemeral
+
+    tmp = Path("/tmp/pgmig_mariadb_to_ts.sql")
+    tmp.write_text("CREATE TABLE users (id int);\nINSERT INTO users VALUES (1);\n", encoding="utf-8")
+    try:
+        for source in ("mysql", "mariadb"):
+            calls["ephemeral"] = 0
+            result = asyncio.run(
+                mod.import_sql_dump_to_live_db(
+                    Mini(), str(tmp), source, {"password": "x"},
+                )
+            )
+            assert calls["ephemeral"] == 1, source
+            assert result.get("_ephemeral_container")
+        print("OK: mysql/mariadb dump routes to ephemeral MySQL when compose has timescale only")
+    finally:
+        mod._compose_text = orig_compose
+        mod.resolve_db_service = orig_resolve
+        mod._import_via_ephemeral_mysql = orig_ephemeral
+        tmp.unlink(missing_ok=True)
+
+
+def test_mysql_ephemeral_passes_create_sql_as_exec_argv():
+    """_mysql_ephemeral must invoke create_subprocess_exec with -e SQL intact."""
+    import asyncio
+    from app.services.native_migration import sql_staging as mod
+
+    captured: list[list[str]] = []
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", None
+
+    async def fake_exec(*argv, **kwargs):
+        captured.append(list(argv))
+        return FakeProc()
+
+    orig = asyncio.create_subprocess_exec
+    asyncio.create_subprocess_exec = fake_exec
+    try:
+        sql = "CREATE DATABASE `pgmig_89b78bab`;"
+        rc, _ = asyncio.run(mod._mysql_ephemeral("c", "pgmigrator", sql=sql))
+        assert rc == 0
+        assert captured, "expected docker exec invocation"
+        argv = captured[0]
+        assert "docker" in argv[0]
+        assert "exec" in argv
+        assert "mysql" in argv
+        assert "-e" in argv
+        e_idx = argv.index("-e")
+        assert argv[e_idx + 1] == sql
+        assert "`pgmig_89b78bab`" in argv[e_idx + 1]
+        # Must not go through a shell string
+        assert not any("CREATE DATABASE ;" in a for a in argv)
+        print("OK: _mysql_ephemeral passes CREATE DATABASE via exec argv")
+    finally:
+        asyncio.create_subprocess_exec = orig
+
+
 if __name__ == "__main__":
     test_filter_timescaledb_extension_in_staging()
     test_compose_has_service_helper()
@@ -216,4 +413,9 @@ if __name__ == "__main__":
     test_timescale_never_stages_into_plain_postgres_compose()
     test_create_staging_db_runs_drop_and_create_separately()
     test_transient_pg_error_detection()
+    test_mysql_shell_e_arg_preserves_backticks()
+    test_mysql_create_db_sql_drop_first()
+    test_mysql_ephemeral_create_uses_exec_not_shell()
+    test_import_mysql_dump_routes_to_ephemeral_when_target_is_timescale()
+    test_mysql_ephemeral_passes_create_sql_as_exec_argv()
     print("\nAll sql staging tests passed.")

--- a/tests/test_sql_staging.py
+++ b/tests/test_sql_staging.py
@@ -258,11 +258,11 @@ def test_mysql_ephemeral_create_uses_exec_not_shell():
 
     calls: list[tuple] = []
 
-    async def fake_mysql(container, pwd, *, sql=None, database=None, stdin_path=None):
-        calls.append({"sql": sql, "database": database, "stdin": stdin_path})
+    async def fake_mysql(container, pwd, *, sql=None, database=None, stdin_path=None, client="mysql"):
+        calls.append({"sql": sql, "database": database, "stdin": stdin_path, "client": client})
         return 0, "ok"
 
-    async def fake_ready(container, pwd, attempts=90):
+    async def fake_ready(container, pwd, attempts=90, *, client="mysql", admin_client="mysqladmin"):
         return None
 
     class Job:
@@ -286,11 +286,12 @@ def test_mysql_ephemeral_create_uses_exec_not_shell():
     try:
         result = asyncio.run(
             mod._import_via_ephemeral_mysql(
-                Mini(), tmp, {}, "pgmig_89b78bab", "pgmig-mysql-test",
+                Mini(), tmp, {}, "pgmig_89b78bab", "pgmig-mysql-test", "mysql",
             )
         )
         assert result["database"] == "pgmig_89b78bab"
         assert result.get("_ephemeral_container") == "pgmig-mysql-test"
+        assert result.get("_ephemeral_image") == "mysql:8"
         assert any(
             c["sql"] and "CREATE DATABASE `pgmig_89b78bab`" in c["sql"]
             for c in calls
@@ -305,15 +306,72 @@ def test_mysql_ephemeral_create_uses_exec_not_shell():
         tmp.unlink(missing_ok=True)
 
 
+def test_ephemeral_mariadb_uses_mariadb_image():
+    """MariaDB dumps must stage into mariadb:11 (not mysql:8) for collations."""
+    import asyncio
+    from app.services.native_migration import sql_staging as mod
+
+    assert mod._ephemeral_mysql_runtime("mariadb") == (
+        "mariadb:11", "mariadb", "mariadb-admin",
+    )
+    assert mod._ephemeral_mysql_runtime("mysql") == (
+        "mysql:8", "mysql", "mysqladmin",
+    )
+
+    run_cmds: list[list] = []
+
+    async def fake_mysql(container, pwd, *, sql=None, database=None, stdin_path=None, client="mysql"):
+        assert client == "mariadb"
+        return 0, "ok"
+
+    async def fake_ready(container, pwd, attempts=90, *, client="mysql", admin_client="mysqladmin"):
+        assert client == "mariadb"
+        assert admin_client == "mariadb-admin"
+
+    class Job:
+        def log(self, *_a, **_k):
+            pass
+
+    class Mini:
+        def __init__(self):
+            self.job = Job()
+
+        async def _run_cmd(self, cmd, timeout=60, cwd=None):
+            run_cmds.append(list(cmd))
+            return True, "ok"
+
+    tmp = Path("/tmp/pgmig_maria_ephemeral_test.sql")
+    tmp.write_text("CREATE TABLE t (id int);\n", encoding="utf-8")
+    orig_mysql = mod._mysql_ephemeral
+    orig_ready = mod._wait_ephemeral_mysql_ready
+    mod._mysql_ephemeral = fake_mysql
+    mod._wait_ephemeral_mysql_ready = fake_ready
+    try:
+        result = asyncio.run(
+            mod._import_via_ephemeral_mysql(
+                Mini(), tmp, {}, "pgmig_deadbeef", "pgmig-mysql-maria", "mariadb",
+            )
+        )
+        assert result["_ephemeral_image"] == "mariadb:11"
+        docker_run = next(c for c in run_cmds if c[:2] == ["docker", "run"])
+        assert "mariadb:11" in docker_run
+        print("OK: ephemeral MariaDB staging uses mariadb:11 + mariadb client")
+    finally:
+        mod._mysql_ephemeral = orig_mysql
+        mod._wait_ephemeral_mysql_ready = orig_ready
+        tmp.unlink(missing_ok=True)
+
+
 def test_import_mysql_dump_routes_to_ephemeral_when_target_is_timescale():
     """MariaDB/MySQL → Timescale: no mysql compose service → ephemeral MySQL."""
     import asyncio
     from app.services.native_migration import sql_staging as mod
 
-    calls = {"ephemeral": 0}
+    calls = {"ephemeral": 0, "sources": []}
 
-    async def fake_ephemeral(migrator, dump_path, conn, staging_db, container):
+    async def fake_ephemeral(migrator, dump_path, conn, staging_db, container, source_db="mysql"):
         calls["ephemeral"] += 1
+        calls["sources"].append(source_db)
         assert staging_db.startswith("pgmig_")
         assert container.startswith("pgmig-mysql-")
         return {
@@ -357,6 +415,7 @@ def test_import_mysql_dump_routes_to_ephemeral_when_target_is_timescale():
                 )
             )
             assert calls["ephemeral"] == 1, source
+            assert calls["sources"][-1] == source
             assert result.get("_ephemeral_container")
         print("OK: mysql/mariadb dump routes to ephemeral MySQL when compose has timescale only")
     finally:
@@ -416,6 +475,7 @@ if __name__ == "__main__":
     test_mysql_shell_e_arg_preserves_backticks()
     test_mysql_create_db_sql_drop_first()
     test_mysql_ephemeral_create_uses_exec_not_shell()
+    test_ephemeral_mariadb_uses_mariadb_image()
     test_import_mysql_dump_routes_to_ephemeral_when_target_is_timescale()
     test_mysql_ephemeral_passes_create_sql_as_exec_argv()
     print("\nAll sql staging tests passed.")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause (reported error)

When migrating **MariaDB → TimescaleDB**, staging uses an ephemeral container (no MySQL in compose). `CREATE DATABASE` was run via shell with SQL in **double quotes**:

```bash
… -e "CREATE DATABASE `pgmig_89b78bab`;"
```

Bash expands backticks → SQL becomes `CREATE DATABASE ;` →  
`Failed to create ephemeral MySQL database pgmig_…`

## Second bug found by E2E

After fixing CREATE DATABASE, real MariaDB 11 dumps still failed on ephemeral **mysql:8**:

`Unknown collation: 'utf8mb4_uca1400_ai_ci'`

**Fix:** stage `mariadb` dumps on `mariadb:11` with `mariadb` / `mariadb-admin` clients; keep `mysql:8` for `mysql` sources.

## Verified with real Docker

All passed on this agent:

1. Ephemeral CREATE DATABASE + dump import (Timescale-only compose)
2. Live **mariadb:11 → timescale/timescaledb** full schema + row verify (`users`/`admins`/… + extension present)
3. Full path: **mariadb-dump → ephemeral mariadb:11 → Timescale** (the panel convert path)

Unit regressions in `tests/test_sql_staging.py` also pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc32c-10cf-7403-bd8c-93812b7ebec9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc32c-10cf-7403-bd8c-93812b7ebec9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

