### PR TITLE
Fix Phase1 0-row MySQL→Timescale when dump has USE pasarguard

### DIFF
--- a/app/services/native_migration/sql_staging.py
+++ b/app/services/native_migration/sql_staging.py
@@ -56,6 +56,61 @@ def mysql_create_db_sql(db: str, *, drop_first: bool = False) -> str:
     return f"CREATE DATABASE `{safe}`;"
 
 
+_MYSQL_USE_DB_RE = re.compile(
+    r"(?im)^\s*USE\s+[`'\"]?[A-Za-z0-9_]+[`'\"]?\s*;\s*$"
+)
+_MYSQL_CREATE_DB_RE = re.compile(
+    r"(?im)^\s*CREATE\s+DATABASE\b.*?;\s*$"
+)
+_MYSQL_DROP_DB_RE = re.compile(
+    r"(?im)^\s*DROP\s+DATABASE\b.*?;\s*$"
+)
+
+
+def prepare_mysql_dump_for_staging(sql_text: str, staging_db: str) -> tuple[str, int]:
+    """Keep dump objects inside staging_db.
+
+    PasarGuard / mysqldump / mariadb-dump backups often include::
+
+        CREATE DATABASE … `pasarguard`;
+        USE `pasarguard`;
+
+    Importing that into ``pgmig_*`` still switches context, so tables land in
+    ``pasarguard`` while Phase1 reads ``pgmig_*`` → 0 rows and aborted convert.
+    Strip CREATE/DROP/USE database redirects; the client already selects staging_db.
+
+    Returns (rewritten_sql, number_of_stripped_lines).
+    """
+    _safe_mysql_ident(staging_db)  # validate only
+    out: list[str] = []
+    stripped = 0
+    for line in sql_text.splitlines(keepends=True):
+        body = line.strip()
+        if not body or body.startswith("--") or body.startswith("#"):
+            out.append(line)
+            continue
+        if (
+            _MYSQL_USE_DB_RE.match(body)
+            or _MYSQL_CREATE_DB_RE.match(body)
+            or _MYSQL_DROP_DB_RE.match(body)
+        ):
+            stripped += 1
+            continue
+        out.append(line)
+    return "".join(out), stripped
+
+
+def write_mysql_dump_for_staging(dump_path: Path, staging_db: str) -> tuple[Path, int]:
+    """Write a staging-safe dump next to the original; return (path, stripped_count)."""
+    raw = dump_path.read_text(encoding="utf-8", errors="ignore")
+    prepared, stripped = prepare_mysql_dump_for_staging(raw, staging_db)
+    if stripped == 0 and prepared == raw:
+        return dump_path, 0
+    out = dump_path.with_suffix(dump_path.suffix + f".stage-{staging_db}")
+    out.write_text(prepared, encoding="utf-8")
+    return out, stripped
+
+
 async def _import_via_compose_service(
     migrator, dump_path: Path, source_db: str, service: str, conn: dict, staging_db: str,
 ) -> None:
@@ -73,22 +128,35 @@ async def _import_via_compose_service(
             f'mysql -u {user} -p"{pwd}" -e {e_sql}'
         )
         safe_db = _safe_mysql_ident(staging_db)
+        import_path, stripped = write_mysql_dump_for_staging(dump_path, safe_db)
+        if stripped:
+            migrator.job.log(
+                f"Rewrote MySQL dump for staging DB {safe_db} "
+                f"(stripped {stripped} USE/CREATE/DROP DATABASE redirect lines)"
+            )
         import_cmd = (
             f'cd "{cwd}" && docker compose exec -T {service} '
-            f'mysql -u {user} -p"{pwd}" {safe_db} < "{dump_path}"'
+            f'mysql -u {user} -p"{pwd}" {safe_db} < "{import_path}"'
         )
-        for cmd in (create_cmd, import_cmd):
-            proc = await asyncio.create_subprocess_shell(
-                cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-            )
-            out_b, _ = await proc.communicate()
-            if proc.returncode != 0:
-                out = (out_b or b"").decode("utf-8", errors="replace")
-                raise RuntimeError(
-                    f"SQL staging failed (db={staging_db}): {out[-400:]}"
+        try:
+            for cmd in (create_cmd, import_cmd):
+                proc = await asyncio.create_subprocess_shell(
+                    cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
                 )
+                out_b, _ = await proc.communicate()
+                if proc.returncode != 0:
+                    out = (out_b or b"").decode("utf-8", errors="replace")
+                    raise RuntimeError(
+                        f"SQL staging failed (db={staging_db}): {out[-400:]}"
+                    )
+        finally:
+            if import_path != dump_path and import_path.exists():
+                try:
+                    import_path.unlink()
+                except OSError:
+                    pass
         return
 
     # PostgreSQL / TimescaleDB via compose
@@ -185,14 +253,6 @@ async def _import_via_compose_service(
             f'"SELECT timescaledb_post_restore();"'
         )
         await p.wait()
-
-
-def mysql_create_db_sql(db: str, *, drop_first: bool = False) -> str:
-    """Build CREATE DATABASE SQL with backticks (safe when not shell-double-quoted)."""
-    safe = _safe_mysql_ident(db)
-    if drop_first:
-        return f"DROP DATABASE IF EXISTS `{safe}`; CREATE DATABASE `{safe}`;"
-    return f"CREATE DATABASE `{safe}`;"
 
 
 def _ephemeral_mysql_runtime(source_db: str) -> tuple[str, str, str]:
@@ -294,6 +354,69 @@ async def _wait_ephemeral_mysql_ready(
     )
 
 
+async def _count_mysql_table_rows(
+    container: str, pwd: str, database: str, table: str, *, client: str = "mysql",
+) -> int:
+    """Return COUNT(*) for table, or -1 if missing/error."""
+    safe_t = "".join(c for c in table if c.isalnum() or c == "_")
+    if safe_t != table or not safe_t:
+        return -1
+    rc, out = await _mysql_ephemeral(
+        container, pwd, database=database,
+        sql=f"SELECT COUNT(*) FROM `{safe_t}`;",
+        client=client,
+    )
+    if rc != 0:
+        return -1
+    for line in (out or "").splitlines():
+        line = line.strip()
+        if line.isdigit():
+            return int(line)
+        # mariadb may print warnings before the number
+        parts = line.split()
+        if parts and parts[-1].isdigit() and "Warning" not in line:
+            return int(parts[-1])
+    return -1
+
+
+async def _verify_mysql_staging_has_data(
+    migrator, container: str, pwd: str, database: str, *, client: str = "mysql",
+) -> None:
+    """Fail early if dump landed outside staging_db (classic USE redirect)."""
+    critical = ("users", "admins", "hosts", "inbounds", "nodes", "groups")
+    found: dict[str, int] = {}
+    for t in critical:
+        n = await _count_mysql_table_rows(container, pwd, database, t, client=client)
+        if n > 0:
+            found[t] = n
+    if found:
+        migrator.job.log(
+            "Ephemeral staging has data: "
+            + ", ".join(f"{k}={v}" for k, v in found.items())
+        )
+        return
+
+    # Diagnose: did USE divert into another schema?
+    rc, out = await _mysql_ephemeral(
+        container, pwd, client=client,
+        sql=(
+            "SELECT table_schema, table_name FROM information_schema.tables "
+            "WHERE table_schema NOT IN "
+            "('information_schema','mysql','performance_schema','sys') "
+            "AND table_name IN ('users','admins') "
+            "ORDER BY table_schema, table_name;"
+        ),
+    )
+    hint = (out or "").strip()[-400:]
+    raise RuntimeError(
+        f"Ephemeral staging DB `{database}` has 0 rows in "
+        f"users/admins/hosts/inbounds/nodes/groups after dump import. "
+        f"The SQL dump likely contains USE/CREATE DATABASE that redirected "
+        f"data away from the staging database"
+        + (f". Other schemas with panel tables:\n{hint}" if hint else ".")
+    )
+
+
 async def _import_via_ephemeral_mysql(
     migrator,
     dump_path: Path,
@@ -321,6 +444,7 @@ async def _import_via_ephemeral_mysql(
     if not ok:
         raise RuntimeError(f"Failed to start ephemeral MySQL/MariaDB ({image}): {out[-500:]}")
 
+    import_path: Path | None = None
     try:
         migrator.job.log(f"Waiting for ephemeral {image} to finish init...")
         await _wait_ephemeral_mysql_ready(
@@ -336,13 +460,24 @@ async def _import_via_ephemeral_mysql(
                 f"Failed to create ephemeral MySQL database {safe_db}: {create_out[-500:]}"
             )
 
+        import_path, stripped = write_mysql_dump_for_staging(dump_path, safe_db)
+        if stripped:
+            migrator.job.log(
+                f"Rewrote dump for staging DB {safe_db} "
+                f"(stripped {stripped} USE/CREATE/DROP DATABASE redirect lines)"
+            )
+
         rc, import_out = await _mysql_ephemeral(
-            container, pwd, database=safe_db, stdin_path=dump_path, client=client,
+            container, pwd, database=safe_db, stdin_path=import_path, client=client,
         )
         if rc != 0:
             raise RuntimeError(
                 f"Failed to import {source_db} dump into ephemeral {image}: {import_out[-500:]}"
             )
+
+        await _verify_mysql_staging_has_data(
+            migrator, container, pwd, safe_db, client=client,
+        )
     except Exception as e:
         migrator.job.log(f"Ephemeral MySQL staging failed — cleaning up ({e})")
         try:
@@ -353,6 +488,12 @@ async def _import_via_ephemeral_mysql(
             pass
         await migrator._run_cmd(["docker", "rm", "-f", container], timeout=30)
         raise
+    finally:
+        if import_path is not None and import_path != dump_path and import_path.exists():
+            try:
+                import_path.unlink()
+            except OSError:
+                pass
 
     return {
         "host": "127.0.0.1",

--- a/tests/integration_cross_db.py
+++ b/tests/integration_cross_db.py
@@ -507,6 +507,120 @@ def test_ephemeral_mysql_create_database_real_docker():
             subprocess.run(["docker", "rm", "-f", cid], capture_output=True)
 
 
+def test_ephemeral_mysql_use_redirect_lands_in_staging():
+    """Regression: dump with USE `pasarguard` must still fill pgmig_* (Phase1 0-row bug)."""
+    import asyncio
+    import pymysql
+    from app.services.native_migration import sql_staging as mod
+
+    dump = Path(tempfile.mkstemp(suffix="-use.sql")[1])
+    # Realistic mysqldump header that previously diverted data out of staging
+    dump.write_text(
+        "-- MySQL dump\n"
+        "CREATE DATABASE /*!32312 IF NOT EXISTS*/ `pasarguard` "
+        "/*!40100 DEFAULT CHARACTER SET utf8mb4 */;\n"
+        "USE `pasarguard`;\n"
+        "CREATE TABLE users (id INT PRIMARY KEY, username VARCHAR(64));\n"
+        "INSERT INTO users VALUES (1, 'kept_in_staging');\n"
+        "CREATE TABLE admins (id INT PRIMARY KEY, username VARCHAR(64), is_sudo TINYINT);\n"
+        "INSERT INTO admins VALUES (1, 'admin', 1);\n"
+        "CREATE TABLE hosts (id INT PRIMARY KEY, remark VARCHAR(64));\n"
+        "INSERT INTO hosts VALUES (1, 'h1');\n"
+        "CREATE TABLE inbounds (id INT PRIMARY KEY, tag VARCHAR(64));\n"
+        "INSERT INTO inbounds VALUES (1, 'vless');\n"
+        "CREATE TABLE nodes (id INT PRIMARY KEY, name VARCHAR(64));\n"
+        "INSERT INTO nodes VALUES (1, 'n1');\n"
+        "CREATE TABLE `groups` (id INT PRIMARY KEY, name VARCHAR(64));\n"
+        "INSERT INTO `groups` VALUES (1, 'g1');\n",
+        encoding="utf-8",
+    )
+    container = None
+    logs: list[str] = []
+
+    class Job:
+        def log(self, msg, *_a, **_k):
+            logs.append(str(msg))
+
+    class Mini:
+        def __init__(self):
+            self.job = Job()
+
+        async def _run_cmd(self, cmd, timeout=180, cwd=None):
+            try:
+                r = subprocess.run(
+                    cmd, capture_output=True, timeout=timeout, cwd=cwd,
+                )
+                out = (r.stdout or b"").decode() + (r.stderr or b"").decode()
+                return r.returncode == 0, out
+            except Exception as exc:
+                return False, str(exc)
+
+    orig_compose = mod._compose_text
+    orig_resolve = mod.resolve_db_service
+    mod._compose_text = lambda: (
+        "services:\n  timescaledb:\n    image: timescale/timescaledb:latest-pg16\n"
+    )
+    mod.resolve_db_service = lambda db: "timescaledb" if db == "timescaledb" else None
+    try:
+        # backup=mysql path (matches user log)
+        result = asyncio.run(
+            mod.import_sql_dump_to_live_db(
+                Mini(), str(dump), "mysql", {"password": "x"},
+            )
+        )
+        container = result["_ephemeral_container"]
+        staging = result["database"]
+        assert staging.startswith("pgmig_"), result
+        assert any("stripped" in m.lower() or "rewrote" in m.lower() for m in logs), logs
+
+        conn = pymysql.connect(
+            host=result["host"], port=int(result["port"]),
+            user=result["user"], password=result["password"],
+            database=staging,
+        )
+        cur = conn.cursor()
+        cur.execute("SELECT username FROM users WHERE id=1")
+        assert cur.fetchone()[0] == "kept_in_staging"
+        for tbl, n in (
+            ("users", 1), ("admins", 1), ("hosts", 1),
+            ("inbounds", 1), ("nodes", 1), ("groups", 1),
+        ):
+            cur.execute(f"SELECT COUNT(*) FROM `{tbl}`")
+            assert cur.fetchone()[0] == n, tbl
+        # Data must NOT only live in pasarguard
+        cur.execute(
+            "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_schema=%s AND table_name='users'",
+            (staging,),
+        )
+        assert cur.fetchone()[0] == 1
+        conn.close()
+
+        # Phase1-style pre-count must see rows
+        from app.services.native_migration.adapters import create_reader, _count_source_rows
+        reader = create_reader("mysql", None, result)
+        try:
+            pre = {t: _count_source_rows(reader, t) for t in (
+                "users", "admins", "hosts", "inbounds", "nodes", "groups",
+            )}
+            assert any(v > 0 for v in pre.values()), pre
+        finally:
+            reader.close()
+        print("OK: USE/CREATE DATABASE dump lands in pgmig_* staging (Phase1 rows > 0)")
+    finally:
+        mod._compose_text = orig_compose
+        mod.resolve_db_service = orig_resolve
+        dump.unlink(missing_ok=True)
+        if container:
+            subprocess.run(["docker", "rm", "-f", container], capture_output=True)
+        out = subprocess.run(
+            ["docker", "ps", "-aq", "--filter", "name=pgmig-mysql-"],
+            capture_output=True, text=True,
+        )
+        for cid in (out.stdout or "").split():
+            subprocess.run(["docker", "rm", "-f", cid], capture_output=True)
+
+
 def test_mariadb_to_timescaledb_full_schema():
     """Live MariaDB → TimescaleDB universal copy with row verification."""
     import psycopg2
@@ -1132,6 +1246,7 @@ if __name__ == "__main__":
     test_mysql_to_postgres_full_schema()
     # MariaDB → TimescaleDB (reported failure path)
     test_ephemeral_mysql_create_database_real_docker()
+    test_ephemeral_mysql_use_redirect_lands_in_staging()
     test_mariadb_to_timescaledb_full_schema()
     test_mariadb_dump_ephemeral_then_timescaledb()
     print("\nAll integration tests passed.")

--- a/tests/test_sql_staging.py
+++ b/tests/test_sql_staging.py
@@ -251,6 +251,31 @@ def test_mysql_create_db_sql_drop_first():
     print("OK: mysql_create_db_sql validates names")
 
 
+def test_prepare_mysql_dump_strips_use_and_create_database():
+    """Regression: USE pasarguard diverts data away from pgmig_* staging DB."""
+    from app.services.native_migration.sql_staging import prepare_mysql_dump_for_staging
+
+    raw = "\n".join([
+        "-- MySQL dump",
+        "CREATE DATABASE /*!32312 IF NOT EXISTS*/ `pasarguard` /*!40100 DEFAULT CHARACTER SET utf8mb4 */;",
+        "USE `pasarguard`;",
+        "DROP DATABASE IF EXISTS `old`;",
+        "CREATE TABLE users (id INT);",
+        "INSERT INTO users VALUES (1);",
+        "USE marzban;",
+        "",
+    ])
+    out, stripped = prepare_mysql_dump_for_staging(raw, "pgmig_deadbeef")
+    assert stripped >= 3, stripped
+    assert "USE `pasarguard`" not in out
+    assert "USE marzban" not in out
+    assert "CREATE DATABASE" not in out
+    assert "DROP DATABASE" not in out
+    assert "CREATE TABLE users" in out
+    assert "INSERT INTO users VALUES (1);" in out
+    print("OK: prepare_mysql_dump strips USE/CREATE/DROP DATABASE")
+
+
 def test_mysql_ephemeral_create_uses_exec_not_shell():
     """CREATE DATABASE must go through docker exec argv, never shell -e."""
     import asyncio
@@ -263,6 +288,9 @@ def test_mysql_ephemeral_create_uses_exec_not_shell():
         return 0, "ok"
 
     async def fake_ready(container, pwd, attempts=90, *, client="mysql", admin_client="mysqladmin"):
+        return None
+
+    async def fake_verify(*_a, **_k):
         return None
 
     class Job:
@@ -281,8 +309,10 @@ def test_mysql_ephemeral_create_uses_exec_not_shell():
 
     orig_mysql = mod._mysql_ephemeral
     orig_ready = mod._wait_ephemeral_mysql_ready
+    orig_verify = mod._verify_mysql_staging_has_data
     mod._mysql_ephemeral = fake_mysql
     mod._wait_ephemeral_mysql_ready = fake_ready
+    mod._verify_mysql_staging_has_data = fake_verify
     try:
         result = asyncio.run(
             mod._import_via_ephemeral_mysql(
@@ -303,6 +333,7 @@ def test_mysql_ephemeral_create_uses_exec_not_shell():
     finally:
         mod._mysql_ephemeral = orig_mysql
         mod._wait_ephemeral_mysql_ready = orig_ready
+        mod._verify_mysql_staging_has_data = orig_verify
         tmp.unlink(missing_ok=True)
 
 
@@ -328,6 +359,9 @@ def test_ephemeral_mariadb_uses_mariadb_image():
         assert client == "mariadb"
         assert admin_client == "mariadb-admin"
 
+    async def fake_verify(*_a, **_k):
+        return None
+
     class Job:
         def log(self, *_a, **_k):
             pass
@@ -344,8 +378,10 @@ def test_ephemeral_mariadb_uses_mariadb_image():
     tmp.write_text("CREATE TABLE t (id int);\n", encoding="utf-8")
     orig_mysql = mod._mysql_ephemeral
     orig_ready = mod._wait_ephemeral_mysql_ready
+    orig_verify = mod._verify_mysql_staging_has_data
     mod._mysql_ephemeral = fake_mysql
     mod._wait_ephemeral_mysql_ready = fake_ready
+    mod._verify_mysql_staging_has_data = fake_verify
     try:
         result = asyncio.run(
             mod._import_via_ephemeral_mysql(
@@ -359,6 +395,7 @@ def test_ephemeral_mariadb_uses_mariadb_image():
     finally:
         mod._mysql_ephemeral = orig_mysql
         mod._wait_ephemeral_mysql_ready = orig_ready
+        mod._verify_mysql_staging_has_data = orig_verify
         tmp.unlink(missing_ok=True)
 
 
@@ -474,6 +511,7 @@ if __name__ == "__main__":
     test_transient_pg_error_detection()
     test_mysql_shell_e_arg_preserves_backticks()
     test_mysql_create_db_sql_drop_first()
+    test_prepare_mysql_dump_strips_use_and_create_database()
     test_mysql_ephemeral_create_uses_exec_not_shell()
     test_ephemeral_mariadb_uses_mariadb_image()
     test_import_mysql_dump_routes_to_ephemeral_when_target_is_timescale()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the ephemeral `CREATE DATABASE` fix, MariaDB/MySQL → Timescale still failed with:

`Phase1 intermediate has 0 rows in users/admins/hosts/inbounds/nodes/groups`

Logs showed alembic upgrading the staging DB, then the 0-row abort. That matches an **empty** `pgmig_*` schema (alembic creates tables; dump data never landed there).

## Root cause

PasarGuard `db_backup.sql` / mysqldump often contains:

```sql
CREATE DATABASE … `pasarguard`;
USE `pasarguard`;
```

Import was opened as `mysql … pgmig_xxx < dump`, but `USE` switches context, so rows go into `pasarguard` while Phase1 reads `pgmig_xxx` → 0 rows.

Reproduced with Docker: staging has no `users` table; `pasarguard.users` has the data.

## Fix

- Strip `USE` / `CREATE DATABASE` / `DROP DATABASE` lines before staging import (`prepare_mysql_dump_for_staging`)
- Apply on ephemeral + compose MySQL paths
- Verify staging has panel rows immediately after import (clear error if still empty)

## Tests

- Unit: strip USE/CREATE DATABASE
- Docker E2E: dump with `USE pasarguard` → rows in `pgmig_*` + Phase1-style counts > 0
- Existing MariaDB → Timescale E2E still passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc32c-10cf-7403-bd8c-93812b7ebec9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc32c-10cf-7403-bd8c-93812b7ebec9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

