### PR TITLE
Fix TimescaleDB restore: chunk.schema_name catalog mismatch (v2.0.3)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.0.2`** — Always take a full backup before restore or migration.
+> ⚠️ **`v2.0.3`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -55,6 +55,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v2.0.3 | Fix Timescale restore: detect old chunk.schema_name catalog and pin image to 2.28.3 on 2.29+ hosts |
 | v2.0.2 | Fix MariaDB→Timescale migrate (ephemeral CREATE DATABASE + stage on mariadb:11) |
 | v2.0.1 | Panel/sub redirect prefers PasarGuard domain, else IP; tracks later .env/domain changes |
 | v2.0 | Full 3X-UI migrate (auto old/new schema, Host/Admin/Group, redirect path/port) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v2.0.2`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v2.0.3`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -57,6 +57,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v2.0.3 | فیکس ریستور Timescale: تشخیص کاتالوگ قدیمی chunk.schema_name و پین ایمیج به 2.28.3 روی سرورهای 2.29+ |
 | v2.0.2 | فیکس مهاجرت MariaDB→Timescale (ساخت DB موقت + staging با mariadb:11) |
 | v2.0.1 | ریدایرکت/لینک پنل: اولویت دامنه پاسارگارد، در غیر این‌صورت IP؛ دنبال‌کردن تغییر دامنه/.env |
 | v2.0 | مهاجرت کامل 3X-UI قدیم/جدید (تشخیص خودکار، Host/Admin/Group، ریدایرکت path/port) |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.0.2`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v2.0.3`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -55,6 +55,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v2.0.3 | Исправление restore Timescale: детект старого каталога chunk.schema_name и pin образа на 2.28.3 для хостов 2.29+ |
 | v2.0.2 | Исправление миграции MariaDB→Timescale (CREATE DATABASE + staging на mariadb:11) |
 | v2.0.1 | Redirect/панель: домен PasarGuard приоритетнее IP; отслеживает смену .env/домена |
 | v2.0 | Полная миграция 3X-UI (авто old/new, Host/Admin/Group, redirect path/port) |

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "2.0.2"
+APP_VERSION = "2.0.3"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -179,6 +179,13 @@ def _sql_literal(value: str) -> str:
     return "'" + (value or "").replace("'", "''") + "'"
 
 
+# TimescaleDB 2.29.0 replaced chunk.schema_name/table_name with relid.
+# Restoring a pre-2.29 dump into 2.29+ fails with:
+#   ERROR: column "schema_name" of relation "chunk" does not exist
+TS_LAST_SCHEMA_NAME_CHUNK = "2.28.3"
+TS_FIRST_RELID_CHUNK = "2.29.0"
+
+
 def parse_timescale_wanted(versions: list[str] | None) -> str | None:
     """Pick a concrete TimescaleDB version like 2.28.1 from backup metadata."""
     if not versions:
@@ -190,6 +197,30 @@ def parse_timescale_wanted(versions: list[str] | None) -> str | None:
         if re.match(r"^\d+\.\d+(\.\d+)?$", v):
             scored.append(v)
     return scored[0] if scored else (versions[0].strip() or None)
+
+
+def _ts_version_tuple(ver: str | None) -> tuple[int, ...] | None:
+    """Parse dotted Timescale version into a comparable tuple."""
+    if not ver:
+        return None
+    m = re.match(r"^(\d+)\.(\d+)(?:\.(\d+))?", (ver or "").strip())
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3) or 0))
+
+
+def ts_version_ge(a: str | None, b: str | None) -> bool:
+    ta, tb = _ts_version_tuple(a), _ts_version_tuple(b)
+    if ta is None or tb is None:
+        return False
+    return ta >= tb
+
+
+def ts_version_lt(a: str | None, b: str | None) -> bool:
+    ta, tb = _ts_version_tuple(a), _ts_version_tuple(b)
+    if ta is None or tb is None:
+        return False
+    return ta < tb
 
 
 def detect_ts_mismatch_from_text(text: str) -> tuple[str, str] | None:
@@ -211,6 +242,301 @@ def detect_ts_mismatch_from_text(text: str) -> tuple[str, str] | None:
     if m2:
         return m2.group(1), m2.group(2)
     return None
+
+
+def is_ts_catalog_mismatch_error(text: str) -> bool:
+    """True when psql failed because Timescale catalog columns don't match the dump era.
+
+    Classic case after TimescaleDB 2.29.0: dump COPY lists schema_name/table_name on
+    _timescaledb_catalog.chunk, but the live extension only has relid.
+    """
+    if not text:
+        return False
+    low = text.lower()
+    catalog_cols = (
+        "schema_name",
+        "table_name",
+        "relid",
+        "compressed_chunk_id",
+        "compression_state",
+        "compressed_hypertable_id",
+    )
+    if "of relation \"chunk\"" in low or "of relation 'chunk'" in low:
+        if any(c in low for c in catalog_cols) and (
+            "does not exist" in low or "undefined_column" in low
+        ):
+            return True
+    if "of relation \"hypertable\"" in low or "of relation 'hypertable'" in low:
+        if any(c in low for c in ("compression_state", "compressed_hypertable_id", "status")) and (
+            "does not exist" in low or "undefined_column" in low
+        ):
+            return True
+    # COPY column list / INSERT target mismatches against Timescale catalogs
+    if "_timescaledb_catalog" in low and "does not exist" in low and any(
+        c in low for c in catalog_cols
+    ):
+        return True
+    return False
+
+
+def detect_dump_chunk_catalog_era(sql_text: str) -> str | None:
+    """Return 'schema_name' (pre-2.29) or 'relid' (2.29+) from dump COPY headers."""
+    if not sql_text:
+        return None
+    # COPY [_timescaledb_catalog.]chunk (col, ...) FROM stdin;
+    for m in re.finditer(
+        r"COPY\s+(?:_timescaledb_catalog\.)?chunk\s*\(([^)]+)\)\s+FROM\s+stdin",
+        sql_text,
+        re.I,
+    ):
+        cols = {c.strip().strip('"').lower() for c in m.group(1).split(",")}
+        if "schema_name" in cols or "table_name" in cols:
+            return "schema_name"
+        if "relid" in cols:
+            return "relid"
+    # Fallback: bare column mentions next to catalog.chunk in dump
+    if re.search(
+        r"_timescaledb_catalog\.chunk[^\n]{0,200}\bschema_name\b",
+        sql_text,
+        re.I,
+    ):
+        return "schema_name"
+    if re.search(
+        r"_timescaledb_catalog\.chunk[^\n]{0,200}\brelid\b",
+        sql_text,
+        re.I,
+    ):
+        return "relid"
+    return None
+
+
+def _iter_backup_sql_texts(root: Path, *, max_files: int = 8, max_bytes: int = 1_200_000) -> list[str]:
+    """Read a bounded set of dump SQL texts from a backup root.
+
+    For large single dumps, also sample the file tail — Timescale catalog COPY
+    statements often appear late in pg_dump output.
+    """
+    texts: list[str] = []
+    candidates: list[Path] = []
+    single = root / "db_backup.sql"
+    if single.exists():
+        candidates.append(single)
+    pg = root / "pg_dump"
+    if pg.is_dir():
+        candidates.extend(sorted(p for p in pg.glob("*.sql") if p.is_file()))
+    for path in candidates[:max_files]:
+        try:
+            size = path.stat().st_size
+            with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                head = fh.read(max_bytes)
+                texts.append(head)
+                if size > max_bytes:
+                    # Tail sample for late catalog COPY blocks
+                    fh.seek(max(0, size - max_bytes))
+                    tail = fh.read(max_bytes)
+                    if tail and tail != head:
+                        texts.append(tail)
+        except OSError:
+            continue
+    return texts
+
+
+def detect_backup_chunk_catalog_era(root: Path) -> str | None:
+    """Scan backup dumps for Timescale chunk catalog era."""
+    candidates: list[Path] = []
+    single = root / "db_backup.sql"
+    if single.exists():
+        candidates.append(single)
+    pg = root / "pg_dump"
+    if pg.is_dir():
+        candidates.extend(sorted(p for p in pg.glob("*.sql") if p.is_file()))
+    for path in candidates[:8]:
+        era = _scan_file_chunk_catalog_era(path)
+        if era:
+            return era
+        # Fallback samples if streaming missed oddly wrapped SQL
+        try:
+            size = path.stat().st_size
+            with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                era = detect_dump_chunk_catalog_era(fh.read(1_200_000))
+                if era:
+                    return era
+                if size > 1_200_000:
+                    fh.seek(max(0, size - 1_200_000))
+                    era = detect_dump_chunk_catalog_era(fh.read(1_200_000))
+                    if era:
+                        return era
+        except OSError:
+            continue
+    return None
+
+
+def _scan_file_chunk_catalog_era(path: Path) -> str | None:
+    """Stream-scan a dump for COPY _timescaledb_catalog.chunk (...) headers."""
+    copy_start = re.compile(
+        r"COPY\s+(?:_timescaledb_catalog\.)?chunk\s*\(",
+        re.I,
+    )
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            buf = ""
+            while True:
+                piece = fh.read(256_000)
+                if not piece:
+                    break
+                buf = (buf[-500:] + piece) if buf else piece
+                m = copy_start.search(buf)
+                if not m:
+                    continue
+                rest = buf[m.end() - 1:]  # from '('
+                while ")" not in rest:
+                    more = fh.read(64_000)
+                    if not more:
+                        break
+                    rest += more
+                end = rest.find(")")
+                if end < 0:
+                    continue
+                cols_blob = rest[1:end]
+                cols = {c.strip().strip('"').lower() for c in cols_blob.split(",")}
+                if "schema_name" in cols or "table_name" in cols:
+                    return "schema_name"
+                if "relid" in cols:
+                    return "relid"
+    except OSError:
+        return None
+    return None
+
+
+def _parse_compose_ts_versions(root: Path) -> list[str]:
+    """Read timescale/timescaledb:X.Y.Z image pins from backup compose files."""
+    versions: list[str] = []
+    for name in (
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "compose.yml",
+        "compose.yaml",
+    ):
+        path = root / name
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for m in re.finditer(
+            r"timescale/timescaledb:(\d+\.\d+(?:\.\d+)?)",
+            text,
+            re.I,
+        ):
+            versions.append(m.group(1))
+    return versions
+
+
+def _parse_sql_ts_versions(sql_text: str) -> list[str]:
+    """Best-effort Timescale version strings embedded in dump SQL / comments."""
+    if not sql_text:
+        return []
+    found: list[str] = []
+    patterns = (
+        r"timescaledb[_ -]?version[:\s\"]+(\d+\.\d+(?:\.\d+)?)",
+        r"backup version[:\s]+(\d+\.\d+(?:\.\d+)?)",
+        r"timescale/timescaledb:(\d+\.\d+(?:\.\d+)?)",
+        r"extension[:\s]+timescaledb[^\n]{0,80}?(\d+\.\d+\.\d+)",
+    )
+    for pat in patterns:
+        for m in re.finditer(pat, sql_text, re.I):
+            found.append(m.group(1))
+    return found
+
+
+def infer_ts_version_from_catalog_era(era: str | None) -> str | None:
+    """Map dump catalog fingerprint to a concrete Docker-taggable Timescale version."""
+    if era == "schema_name":
+        return TS_LAST_SCHEMA_NAME_CHUNK
+    if era == "relid":
+        return TS_FIRST_RELID_CHUNK
+    return None
+
+
+def resolve_wanted_ts_for_live(
+    wanted: str | None,
+    *,
+    live_ver: str | None,
+    catalog_era: str | None,
+) -> str | None:
+    """Choose Timescale image version that can accept this dump on the live server.
+
+    Prefer an explicit backup version. When missing, use catalog-era inference so
+    pre-2.29 dumps (schema_name on chunk) are not restored into latest-pg17 (2.29+).
+    """
+    if catalog_era == "schema_name":
+        # Dump COPY lists schema_name — cannot land on TimescaleDB 2.29+
+        if not live_ver or ts_version_ge(live_ver, TS_FIRST_RELID_CHUNK):
+            if wanted and ts_version_lt(wanted, TS_FIRST_RELID_CHUNK):
+                return wanted
+            return TS_LAST_SCHEMA_NAME_CHUNK
+        # Live already pre-2.29 and catalog-compatible
+        if wanted and wanted != live_ver:
+            return wanted
+        return None
+    if catalog_era == "relid":
+        if not live_ver or ts_version_lt(live_ver, TS_FIRST_RELID_CHUNK):
+            if wanted and ts_version_ge(wanted, TS_FIRST_RELID_CHUNK):
+                return wanted
+            return TS_FIRST_RELID_CHUNK
+        if wanted and wanted != live_ver:
+            return wanted
+        return None
+    if wanted and live_ver and wanted != live_ver:
+        return wanted
+    if wanted and not live_ver:
+        return wanted
+    return None
+
+
+def wanted_ts_for_restore_retry(out: str, analysis: dict) -> str | None:
+    """Pick Timescale version to align to after a failed dump restore attempt."""
+    mismatch = detect_ts_mismatch_from_text(out or "")
+    if mismatch and mismatch[0]:
+        return mismatch[0]
+    wanted = parse_timescale_wanted(analysis.get("timescaledb_versions"))
+    if wanted:
+        era = analysis.get("timescaledb_chunk_catalog")
+        if era == "schema_name" and ts_version_ge(wanted, TS_FIRST_RELID_CHUNK):
+            return TS_LAST_SCHEMA_NAME_CHUNK
+        return wanted
+    if is_ts_catalog_mismatch_error(out or ""):
+        era = analysis.get("timescaledb_chunk_catalog")
+        if not era:
+            low = (out or "").lower()
+            if "schema_name" in low or "table_name" in low or "compressed_chunk_id" in low:
+                era = "schema_name"
+            elif "relid" in low:
+                era = "relid"
+        return infer_ts_version_from_catalog_era(era) or TS_LAST_SCHEMA_NAME_CHUNK
+    return None
+
+
+def collect_backup_ts_versions(root: Path) -> list[str]:
+    """Gather explicit Timescale versions from manifest, compose, and dump SQL.
+
+    Catalog fingerprints (schema_name vs relid) are tracked separately via
+    detect_backup_chunk_catalog_era() — they must not be injected as fake
+    semver pins that force unnecessary image realigns on already-compatible hosts.
+    """
+    versions = list(_parse_manifest_ts_versions(root))
+    versions.extend(_parse_compose_ts_versions(root))
+    for text in _iter_backup_sql_texts(root):
+        versions.extend(_parse_sql_ts_versions(text))
+    out: list[str] = []
+    seen: set[str] = set()
+    for v in versions:
+        v = (v or "").strip()
+        if v and v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out
 
 
 def is_auth_failure_text(text: str) -> bool:
@@ -318,10 +644,11 @@ def analyze_pasarguard_backup(upload_id: str | None = None, path: str | Path | N
         elif (root / "db.sqlite3").exists() or list(root.rglob("db.sqlite3")):
             layout = "sqlite_file"
 
-        ts_versions = _parse_manifest_ts_versions(root)
+        ts_versions = collect_backup_ts_versions(root)
+        chunk_catalog_era = detect_backup_chunk_catalog_era(root)
         # Official Timescale backups keep postgresql+asyncpg URL — use manifest / dump hints
         if db_type in (None, "postgresql"):
-            if ts_versions:
+            if ts_versions or chunk_catalog_era:
                 db_type = "timescaledb"
             elif _backup_sql_mentions_timescale(root):
                 db_type = "timescaledb"
@@ -394,6 +721,21 @@ def analyze_pasarguard_backup(upload_id: str | None = None, path: str | Path | N
                 "fa": f"نسخه TimescaleDB بکاپ: {', '.join(sorted(set(ts_versions)))}. قبل از ریستور ایمیج سرور هم‌تراز می‌شود.",
                 "ru": f"TimescaleDB в бэкапе: {', '.join(sorted(set(ts_versions)))}. Образ будет выровнен автоматически.",
             })
+        elif chunk_catalog_era == "schema_name":
+            warnings.append({
+                "en": (
+                    f"Backup uses pre-2.29 Timescale chunk catalog (schema_name). "
+                    f"Wizard will pin image to {TS_LAST_SCHEMA_NAME_CHUNK} before restore."
+                ),
+                "fa": (
+                    f"بکاپ کاتالوگ قدیمی Timescale (schema_name قبل از 2.29) دارد. "
+                    f"قبل از ریستور ایمیج روی {TS_LAST_SCHEMA_NAME_CHUNK} پین می‌شود."
+                ),
+                "ru": (
+                    f"Бэкап со старым каталогом Timescale (schema_name до 2.29). "
+                    f"Образ будет закреплён на {TS_LAST_SCHEMA_NAME_CHUNK}."
+                ),
+            })
 
         # table_counts kept for server-side verify only — not shown in the wizard UI
 
@@ -410,6 +752,7 @@ def analyze_pasarguard_backup(upload_id: str | None = None, path: str | Path | N
             "supported_target_dbs": sorted(SUPPORTED_RESTORE_DBS),
             "layout": layout,
             "timescaledb_versions": sorted(set(ts_versions)),
+            "timescaledb_chunk_catalog": chunk_catalog_era,
             "table_counts": table_counts,
             "env_summary": {k: v for k, v in (summary or {}).items() if k != "db_password"},
             "has_env": bool(env_path),
@@ -1079,6 +1422,16 @@ def explain_restore_error(exc: Exception, backup_db: str | None = None, target_d
         fa = "نسخه TimescaleDB بکاپ با سرور هم‌خوان نیست."
         en = "TimescaleDB version mismatch between backup and server."
         causes_fa = ["ویزارد معمولاً ایمیج را هم‌تراز می‌کند — دوباره تلاش کنید یا لاگ کامل را ببینید."]
+    elif is_ts_catalog_mismatch_error(raw) or (
+        "schema_name" in low and "chunk" in low and "does not exist" in low
+    ):
+        fa = "کاتالوگ TimescaleDB بکاپ با نسخه نصب‌شده سازگار نیست (مثلاً schema_name در chunk)."
+        en = "TimescaleDB catalog in the backup does not match the installed extension (e.g. chunk.schema_name)."
+        causes_fa = [
+            f"از TimescaleDB 2.29 ستون schema_name از جدول chunk حذف شده — بکاپ‌های قدیمی نیاز به ایمیج {TS_LAST_SCHEMA_NAME_CHUNK} دارند",
+            "ویزارد در نسخه جدید اثر انگشت دامپ را تشخیص می‌دهد و ایمیج را قبل از ریستور هم‌تراز می‌کند — آپدیت کنید و دوباره ریستور کنید",
+            "اگر هنوز خطا می‌دهد، در docker-compose.yml ایمیج timescaledb را دستی روی 2.28.3-pgXX بگذارید و volume را پاک کنید",
+        ]
     elif (
         "certificate files were not restored" in low
         or "certs restore failed" in low
@@ -1666,7 +2019,13 @@ async def _restore_backup(job: MigrationJob, params: dict, analysis: dict) -> di
         # Hard convert (timescale → mysql) must not run psql against the mysql container.
         ts_versions = analysis.get("timescaledb_versions") or []
         wanted_ts = parse_timescale_wanted(ts_versions)
-        if installed_db in ("timescaledb", "postgresql") and wanted_ts:
+        catalog_era = analysis.get("timescaledb_chunk_catalog")
+        if not catalog_era and backup_db in ("timescaledb", "postgresql"):
+            catalog_era = detect_backup_chunk_catalog_era(root)
+            if catalog_era:
+                analysis["timescaledb_chunk_catalog"] = catalog_era
+                job.log(f"Detected Timescale chunk catalog era from dump: {catalog_era}")
+        if installed_db in ("timescaledb", "postgresql"):
             container = await _detect_db_container(job, installed_db)
             live_ver = None
             if container:
@@ -1675,12 +2034,34 @@ async def _restore_backup(job: MigrationJob, params: dict, analysis: dict) -> di
                     cur_pg_pass or "",
                     user=cur_user or "postgres",
                 )
-            if live_ver and live_ver != wanted_ts:
-                job.log(f"TimescaleDB mismatch: live={live_ver} backup={wanted_ts}")
-                await _align_timescaledb_image(job, wanted_ts, wipe_data=True)
-            elif not live_ver and installed_db == "timescaledb":
-                job.log("Could not probe live TimescaleDB — pinning image to backup version")
-                await _align_timescaledb_image(job, wanted_ts, wipe_data=True)
+            # Single-layout dumps often lack manifest versions — infer from chunk catalog era
+            # so pre-2.29 backups are not restored into timescale/timescaledb:latest (2.29+).
+            align_to = resolve_wanted_ts_for_live(
+                wanted_ts, live_ver=live_ver, catalog_era=catalog_era,
+            )
+            if align_to and live_ver and live_ver != align_to:
+                job.log(
+                    f"TimescaleDB mismatch: live={live_ver} backup={align_to}"
+                    + (f" (catalog={catalog_era})" if catalog_era else "")
+                )
+                await _align_timescaledb_image(job, align_to, wipe_data=True)
+            elif align_to and not live_ver and installed_db == "timescaledb":
+                job.log(
+                    f"Could not probe live TimescaleDB — pinning image to backup version {align_to}"
+                )
+                await _align_timescaledb_image(job, align_to, wipe_data=True)
+            elif (
+                catalog_era == "schema_name"
+                and live_ver
+                and ts_version_ge(live_ver, TS_FIRST_RELID_CHUNK)
+                and not align_to
+            ):
+                # Defensive: fingerprint says old dump, live is 2.29+
+                job.log(
+                    f"TimescaleDB catalog era mismatch: dump has schema_name, live={live_ver} — "
+                    f"pinning to {TS_LAST_SCHEMA_NAME_CHUNK}"
+                )
+                await _align_timescaledb_image(job, TS_LAST_SCHEMA_NAME_CHUNK, wipe_data=True)
 
         # Destination = installed panel DB. Soft-family (mysql↔mariadb, pg↔timescale) needs no convert.
         target_db = installed_db or params.get("target_db") or backup_db
@@ -2522,16 +2903,13 @@ async def _restore_postgres(
             if not ok:
                 # Align BEFORE retry — only when target actually has Timescale
                 mismatch = detect_ts_mismatch_from_text(out)
+                catalog_err = is_ts_catalog_mismatch_error(out or "")
                 if use_timescale and (
                     mismatch
+                    or catalog_err
                     or ("timescaledb" in (out or "").lower() and "version" in (out or "").lower())
                 ):
-                    wanted = (
-                        (mismatch[0] if mismatch else parse_timescale_wanted(
-                            analysis.get("timescaledb_versions")
-                        ))
-                        or ""
-                    )
+                    wanted = wanted_ts_for_restore_retry(out or "", analysis) or ""
                     if wanted:
                         job.log(f"Timescale restore error — aligning to {wanted} and retrying {dbn}")
                         # _align_timescaledb_image already starts the container and
@@ -2599,11 +2977,42 @@ async def _restore_postgres(
             )
         await psql("SELECT timescaledb_pre_restore();", db=db_name)
         filtered = root / "db_backup_filtered.sql"
+        dump_text = dump.read_text(encoding="utf-8", errors="ignore")
         filtered.write_text(
-            filter_timescaledb_extension_sql(dump.read_text(encoding="utf-8", errors="ignore")),
+            filter_timescaledb_extension_sql(dump_text),
             encoding="utf-8",
         )
         ok, out = await restore_dump_file(db_name, filtered, tolerant=False)
+        if not ok:
+            wanted = wanted_ts_for_restore_retry(out or "", analysis) or ""
+            if not wanted and is_ts_catalog_mismatch_error(out or ""):
+                era = (
+                    analysis.get("timescaledb_chunk_catalog")
+                    or detect_dump_chunk_catalog_era(dump_text)
+                )
+                wanted = infer_ts_version_from_catalog_era(era) or TS_LAST_SCHEMA_NAME_CHUNK
+            if wanted:
+                job.log(
+                    f"Timescale single-dump restore error — aligning to {wanted} and retrying"
+                )
+                await _align_timescaledb_image(job, wanted, wipe_data=True)
+                await psql(
+                    f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    f"WHERE datname = '{db_name}' AND pid <> pg_backend_pid();"
+                )
+                await psql(f'DROP DATABASE IF EXISTS "{db_name}";')
+                ok_db, out_db = await psql(f'CREATE DATABASE "{db_name}" OWNER "{user}";')
+                if not ok_db:
+                    raise RuntimeError(
+                        f"CREATE DATABASE failed after image align:\n{out_db[-1000:]}"
+                    )
+                await psql("CREATE EXTENSION IF NOT EXISTS timescaledb;", db=db_name)
+                await psql("SELECT timescaledb_pre_restore();", db=db_name)
+                filtered.write_text(
+                    filter_timescaledb_extension_sql(dump_text),
+                    encoding="utf-8",
+                )
+                ok, out = await restore_dump_file(db_name, filtered, tolerant=False)
         ok_post_s, out_post_s = await psql("SELECT timescaledb_post_restore();", db=db_name)
         if not ok_post_s:
             job.log(f"timescaledb_post_restore (single) warning: {extract_psql_errors(out_post_s)[:300]}")

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=2.0.2">
+  <link rel="stylesheet" href="/static/css/style.css?v=2.0.3">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -578,8 +578,8 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=2.0.2"></script>
-  <script src="/static/js/app.js?v=2.0.2"></script>
+  <script src="/static/js/i18n.js?v=2.0.3"></script>
+  <script src="/static/js/app.js?v=2.0.3"></script>
   <script src="/static/js/wizard-flow.js?v=1.1beta.13"></script>
 </body>
 </html>

--- a/tests/test_pg_restore.py
+++ b/tests/test_pg_restore.py
@@ -16,10 +16,18 @@ from app.services.pg_restore import (
     parse_timescale_wanted,
     detect_ts_mismatch_from_text,
     is_auth_failure_text,
+    is_ts_catalog_mismatch_error,
+    detect_dump_chunk_catalog_era,
+    resolve_wanted_ts_for_live,
+    wanted_ts_for_restore_retry,
+    collect_backup_ts_versions,
+    TS_LAST_SCHEMA_NAME_CHUNK,
+    TS_FIRST_RELID_CHUNK,
     _sql_literal,
     _set_env_var,
     _parse_manifest_ts_versions,
     analyze_pasarguard_backup,
+    explain_restore_error,
 )
 
 
@@ -88,6 +96,101 @@ The restore was stopped BEFORE changing anything
     pair = detect_ts_mismatch_from_text(text)
     assert pair == ("2.28.1", "2.28.2")
     print("OK: detect timescale mismatch text")
+
+
+def test_is_ts_catalog_mismatch_error_schema_name():
+    err = 'ERROR:  column "schema_name" of relation "chunk" does not exist'
+    assert is_ts_catalog_mismatch_error(err)
+    assert is_ts_catalog_mismatch_error(
+        'ERROR: column "relid" of relation "chunk" does not exist'
+    )
+    assert not is_ts_catalog_mismatch_error('ERROR: relation "users" does not exist')
+    print("OK: catalog mismatch detection")
+
+
+def test_detect_dump_chunk_catalog_era():
+    old = (
+        "COPY _timescaledb_catalog.chunk (id, hypertable_id, schema_name, "
+        "table_name, compressed_chunk_id, status) FROM stdin;\n"
+    )
+    new = (
+        "COPY _timescaledb_catalog.chunk (id, hypertable_id, relid, status) "
+        "FROM stdin;\n"
+    )
+    assert detect_dump_chunk_catalog_era(old) == "schema_name"
+    assert detect_dump_chunk_catalog_era(new) == "relid"
+    assert detect_dump_chunk_catalog_era("COPY public.users (id) FROM stdin;") is None
+    print("OK: dump chunk catalog era")
+
+
+def test_resolve_wanted_ts_for_live_pins_pre_229():
+    # Live latest (2.29+) + old dump fingerprint → pin 2.28.3
+    assert (
+        resolve_wanted_ts_for_live(None, live_ver="2.29.1", catalog_era="schema_name")
+        == TS_LAST_SCHEMA_NAME_CHUNK
+    )
+    # Live already 2.28.x + old dump → no realign
+    assert (
+        resolve_wanted_ts_for_live(None, live_ver="2.28.1", catalog_era="schema_name")
+        is None
+    )
+    # Explicit older version still preferred when live is 2.29+
+    assert (
+        resolve_wanted_ts_for_live("2.17.2", live_ver="2.29.0", catalog_era="schema_name")
+        == "2.17.2"
+    )
+    # New dump on old live → pin 2.29.0
+    assert (
+        resolve_wanted_ts_for_live(None, live_ver="2.28.3", catalog_era="relid")
+        == TS_FIRST_RELID_CHUNK
+    )
+    print("OK: resolve wanted ts for live")
+
+
+def test_wanted_ts_for_restore_retry_from_catalog_error():
+    err = 'ERROR:  column "schema_name" of relation "chunk" does not exist'
+    assert (
+        wanted_ts_for_restore_retry(err, {"timescaledb_versions": [], "timescaledb_chunk_catalog": "schema_name"})
+        == TS_LAST_SCHEMA_NAME_CHUNK
+    )
+    assert (
+        wanted_ts_for_restore_retry(err, {})
+        == TS_LAST_SCHEMA_NAME_CHUNK
+    )
+    print("OK: wanted ts for restore retry")
+
+
+def test_explain_schema_name_chunk_error():
+    exc = RuntimeError(
+        'PostgreSQL dump restore failed:\nERROR:  column "schema_name" of relation "chunk" does not exist'
+    )
+    info = explain_restore_error(exc, "timescaledb", "timescaledb")
+    assert "schema_name" in (info.get("en") or "").lower() or "catalog" in (info.get("en") or "").lower()
+    assert info.get("causes_fa")
+    print("OK: explain schema_name chunk error")
+
+
+def test_collect_backup_ts_from_compose_and_catalog():
+    import tempfile
+    import shutil
+
+    td = Path(tempfile.mkdtemp(prefix="pg-ts-collect-"))
+    try:
+        (td / "db_backup.sql").write_text(
+            "COPY _timescaledb_catalog.chunk (id, hypertable_id, schema_name, table_name) FROM stdin;\n1\t1\t_timescaledb_internal\t_hyper_1_1_chunk\n\\.\n",
+            encoding="utf-8",
+        )
+        (td / "docker-compose.yml").write_text(
+            "services:\n  timescaledb:\n    image: timescale/timescaledb:2.17.2-pg17\n",
+            encoding="utf-8",
+        )
+        versions = collect_backup_ts_versions(td)
+        assert "2.17.2" in versions
+        from app.services.pg_restore import detect_backup_chunk_catalog_era
+        assert detect_backup_chunk_catalog_era(td) == "schema_name"
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+    print("OK: collect backup ts from compose + catalog")
 
 
 def test_is_auth_failure_text():
@@ -235,6 +338,12 @@ if __name__ == "__main__":
     test_filter_timescaledb_strip_all_for_plain_pg()
     test_parse_timescale_wanted()
     test_detect_ts_mismatch_from_official_error()
+    test_is_ts_catalog_mismatch_error_schema_name()
+    test_detect_dump_chunk_catalog_era()
+    test_resolve_wanted_ts_for_live_pins_pre_229()
+    test_wanted_ts_for_restore_retry_from_catalog_error()
+    test_explain_schema_name_chunk_error()
+    test_collect_backup_ts_from_compose_and_catalog()
     test_is_auth_failure_text()
     test_sql_literal_escapes_quotes()
     test_merge_env_preserves_password()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Restoring older PasarGuard Timescale backups (`layout=single`) into hosts running `timescale/timescaledb:latest` (TimescaleDB **2.29+**) failed with:

```
ERROR: column "schema_name" of relation "chunk" does not exist
```

TimescaleDB 2.29.0 removed `schema_name` / `table_name` from `_timescaledb_catalog.chunk` (replaced by `relid`). Single-dump backups often have no version in `manifest.tsv`, so the wizard never aligned the image before restore.

## Fix
- Detect dump catalog era from `COPY … chunk (…)` column lists (`schema_name` vs `relid`)
- Also read Timescale version pins from backup `docker-compose.yml` when present
- Before restore, pin compose image to **2.28.3** when the dump is pre-2.29 and live is 2.29+
- Retry **single-dump** restores on catalog mismatch (multi path already had version retry)
- Clearer FA/EN error explanation for this failure mode

## Test plan
- [x] Unit tests in `tests/test_pg_restore.py` (catalog era, align resolution, explain, compose version)
- [ ] Re-run the same PasarGuard backup restore that previously failed on a Timescale host
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc53-107b-7c5a-8467-f9ed24a72f1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc53-107b-7c5a-8467-f9ed24a72f1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

