### PR TITLE
Fix Marzban MySQL→Timescale unknown alembic revision (v2.0.4)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.0.3`** — Always take a full backup before restore or migration.
+> ⚠️ **`v2.0.4`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -55,6 +55,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v2.0.4 | Fix Marzban MySQL→Timescale when source alembic_version is missing from PasarGuard (staging-only heal) |
 | v2.0.3 | Fix Timescale restore: detect old chunk.schema_name catalog and pin image to 2.28.3 on 2.29+ hosts |
 | v2.0.2 | Fix MariaDB→Timescale migrate (ephemeral CREATE DATABASE + stage on mariadb:11) |
 | v2.0.1 | Panel/sub redirect prefers PasarGuard domain, else IP; tracks later .env/domain changes |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v2.0.3`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v2.0.4`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -57,6 +57,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v2.0.4 | فیکس مهاجرت Marzban MySQL→Timescale وقتی alembic_version مرزبان در PasarGuard نیست (heal فقط روی staging) |
 | v2.0.3 | فیکس ریستور Timescale: تشخیص کاتالوگ قدیمی chunk.schema_name و پین ایمیج به 2.28.3 روی سرورهای 2.29+ |
 | v2.0.2 | فیکس مهاجرت MariaDB→Timescale (ساخت DB موقت + staging با mariadb:11) |
 | v2.0.1 | ریدایرکت/لینک پنل: اولویت دامنه پاسارگارد، در غیر این‌صورت IP؛ دنبال‌کردن تغییر دامنه/.env |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.0.3`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v2.0.4`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -55,6 +55,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v2.0.4 | Исправление миграции Marzban MySQL→Timescale при неизвестном alembic_version (heal только на staging) |
 | v2.0.3 | Исправление restore Timescale: детект старого каталога chunk.schema_name и pin образа на 2.28.3 для хостов 2.29+ |
 | v2.0.2 | Исправление миграции MariaDB→Timescale (CREATE DATABASE + staging на mariadb:11) |
 | v2.0.1 | Redirect/панель: домен PasarGuard приоритетнее IP; отслеживает смену .env/домена |

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "2.0.3"
+APP_VERSION = "2.0.4"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/services/migrators/marzban.py
+++ b/app/services/migrators/marzban.py
@@ -178,6 +178,12 @@ class MarzbanMigrator(BaseMigrator):
             await self._import_mysql_dump(source_sql)
             if extra_data_dir:
                 await self._copy_marzban_assets(extra_data_dir)
+            # Dump is in PasarGuard target DB (Marzban live untouched). Heal unknown stamp.
+            from app.services.native_migration.cross_db import _heal_staging_alembic_if_unknown
+
+            tconn = dict(get_target_connection(self.params))
+            tconn["_allow_live_alembic_heal"] = True
+            await _heal_staging_alembic_if_unknown(self, source_db, tconn)
             self.job.set_progress(70, "Upgrading Marzban MySQL schema via panel boot...")
             await safe_start_pasarguard(self)
             return

--- a/app/services/native_migration/cross_db.py
+++ b/app/services/native_migration/cross_db.py
@@ -20,9 +20,15 @@ from app.services.pasarguard_ops import (
     build_local_alembic_url,
     run_alembic_upgrade_head,
     read_target_alembic_version,
+    heal_unknown_alembic_revision,
+    read_sqlite_alembic_version,
 )
 from app.services.native_migration.sql_staging import import_sql_dump_to_live_db
 from app.services.native_migration.universal_copy import copy_database_universal
+from app.services.native_migration.source_version import (
+    normalize_alembic_revision,
+    _read_live_alembic_version,
+)
 
 SUPPORTED_ENGINES = frozenset({
     "sqlite", "mysql", "mariadb", "postgresql", "timescaledb",
@@ -165,14 +171,44 @@ async def _reset_target_schema(migrator, target_db: str) -> None:
         migrator.job.log("Warning: target schema reset returned non-zero — continuing")
 
 
+async def _heal_staging_alembic_if_unknown(
+    migrator, db_type: str, conn: dict,
+) -> None:
+    """If staging alembic_version is missing from PasarGuard scripts, re-stamp it."""
+    from app.services.pasarguard_ops import _revision_known_to_pasarguard
+
+    if db_type == "sqlite":
+        path = conn.get("sqlite_path") or ""
+        current = read_sqlite_alembic_version(path) if path else None
+    else:
+        current = _read_live_alembic_version(conn, db_type)
+    current = normalize_alembic_revision(current) if current else None
+    if not current:
+        return
+    if await _revision_known_to_pasarguard(migrator, current):
+        return
+    migrator.job.log(
+        f"Staging alembic_version {current} not in PasarGuard image — healing..."
+    )
+    await heal_unknown_alembic_revision(
+        migrator, db_type, conn, missing_revision=current,
+    )
+
+
 async def _phase1_land_intermediate(
     migrator,
     source_path: str,
     source_db: str,
+    *,
+    skip_alembic: bool = False,
 ) -> tuple[str, str, dict | None]:
     """Land source data on an intermediate DB and upgrade it to alembic head.
 
     Returns (intermediate_path, intermediate_db, staging_conn).
+
+    When skip_alembic=True (Marzban panel-boot path), only land + heal unknown
+    revision stamps — host-network upgrade is deferred so proxies→inbounds
+    transforms are not skipped.
     """
     path = Path(source_path)
     staging_conn: dict | None = None
@@ -188,8 +224,14 @@ async def _phase1_land_intermediate(
         if dest.resolve() != path.resolve():
             shutil.copy2(path, dest)
         migrator.job.log(f"Phase1: intermediate SQLite at {dest}")
+        sqlite_conn = {"sqlite_path": str(dest), "_allow_live_alembic_heal": True}
+        if skip_alembic:
+            await _heal_staging_alembic_if_unknown(migrator, "sqlite", sqlite_conn)
+            return str(dest), "sqlite", None
         url = build_sqlite_alembic_url(dest)
-        await run_alembic_upgrade_head(migrator, url_override=url, heal_db="sqlite")
+        await run_alembic_upgrade_head(
+            migrator, url_override=url, heal_db="sqlite", heal_conn=sqlite_conn,
+        )
         return str(dest), "sqlite", None
 
     # MySQL/MariaDB/PG source: .sql dump → staging, or live connection
@@ -198,18 +240,33 @@ async def _phase1_land_intermediate(
         staging_conn = await import_sql_dump_to_live_db(
             migrator, source_path, source_db, conn,
         )
+        # Dump lands in pgmig_* / ephemeral — never the live Marzban database.
+        await _heal_staging_alembic_if_unknown(migrator, source_db, staging_conn)
+        if skip_alembic:
+            migrator.job.log(
+                "Phase1: skip host alembic (panel-boot will upgrade Marzban schema)"
+            )
+            return source_path, source_db, staging_conn
         url = build_alembic_url_from_conn(source_db, staging_conn)
         await run_alembic_upgrade_head(
-            migrator, url_override=url, heal_db=source_db,
+            migrator,
+            url_override=url,
+            heal_db=source_db,
+            heal_conn=staging_conn,
         )
         return source_path, source_db, staging_conn
 
-    # Live non-sqlite source (credentials from wizard)
+    # Live non-sqlite source (credentials from wizard) — do not heal/stamp live.
     conn = get_source_connection(migrator.params)
+    if skip_alembic:
+        migrator.job.log(
+            "Phase1: live source + panel-boot — host alembic skipped "
+            "(will not mutate live alembic_version)"
+        )
+        return source_path, source_db, None
     url = build_alembic_url_from_conn(source_db, conn)
     await run_alembic_upgrade_head(migrator, url_override=url, heal_db=source_db)
     return source_path, source_db, None
-
 
 async def _prepare_target_for_migration(migrator, target_db: str) -> None:
     """Ensure target DB is up, credentials verified, and role passwords aligned."""
@@ -328,12 +385,17 @@ async def run_two_phase_migration(
     staging_conn: dict | None = None
     try:
         # Phase 1 — land + upgrade intermediate to head
+        # Marzban panel-boot path skips host alembic (avoids early stamp / missing-rev crash).
         migrator.job.set_progress(min(92, base + 3), "Phase 1: intermediate DB → alembic head...")
         inter_path, inter_db, staging_conn = await _phase1_land_intermediate(
-            migrator, source_path, source_db,
+            migrator, source_path, source_db, skip_alembic=upgrade_via_panel,
         )
 
         if upgrade_via_panel:
+            if staging_conn:
+                await _heal_staging_alembic_if_unknown(
+                    migrator, inter_db, staging_conn,
+                )
             migrator.job.set_progress(
                 min(93, base + 5),
                 "Phase 1b: panel-boot Marzban→PasarGuard schema upgrade...",

--- a/app/services/pasarguard_ops.py
+++ b/app/services/pasarguard_ops.py
@@ -19,6 +19,7 @@ STARTUP_MARKERS = (
 FAIL_LOG_PATTERNS = (
     "Database migrations failed",
     "ERROR: Database migrations failed",
+    "Can't locate revision identified by",
     "sqlalchemy.exc.",
     "asyncpg.exceptions.",
     "DuplicateColumnError",
@@ -33,6 +34,15 @@ FAIL_LOG_PATTERNS = (
     "ValueError:",
     "SSL certificate file",
     "column \"user_template_id\" of relation \"next_plans\" already exists",
+)
+
+# Stamp Marzban-shaped DBs (still have `proxies`) just before PasarGuard transforms
+# (gozargah_node → groups → migrate_to_groups → move/drop proxies).
+_MARZBAN_BRIDGE_REVISIONS = (
+    "0b62f893092b",  # parent of c41c441de44c (gozargah-node)
+    "2b231de97dc3",  # common shared Marzban revision
+    "dd725e4d3628",
+    "6980e98bba01",
 )
 
 # Harmless lines from DB restarts — must not fail the panel health check
@@ -876,8 +886,245 @@ async def _run_pasarguard_alembic(
     return False, out or ""
 
 
+def _parse_missing_revision(output: str) -> str | None:
+    """Extract revision id from Alembic 'Can't locate revision identified by 'XXX''."""
+    m = re.search(
+        r"Can't locate revision identified by ['\"]([0-9a-fA-F]+)['\"]",
+        output or "",
+    )
+    return m.group(1).lower() if m else None
+
+
+def _is_missing_revision_error(output: str) -> bool:
+    return _parse_missing_revision(output) is not None
+
+
+def _parse_upgrade_target_revision(output: str) -> str | None:
+    m = re.search(r"Running upgrade\s+\S+\s*->\s*([0-9a-f]+)", output, re.I)
+    if m:
+        return m.group(1)
+    m = re.search(r"versions/([0-9a-f]+)_", output, re.I)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _is_duplicate_schema_error(output: str) -> bool:
+    low = (output or "").lower()
+    return "duplicatecolumn" in low or "already exists" in low
+
+
+def _conn_table_exists(db_type: str, conn: dict, table: str) -> bool:
+    """Check whether a table exists on a live connection (staging-safe)."""
+    host = conn.get("host") or "127.0.0.1"
+    port = int(migration_port(conn, db_type))
+    user = conn.get("user") or (
+        "postgres" if db_type in ("postgresql", "timescaledb") else "root"
+    )
+    password = conn.get("password") or ""
+    database = conn.get("database") or "pasarguard"
+    table_l = (table or "").lower()
+    try:
+        if db_type == "sqlite":
+            path = conn.get("sqlite_path") or str(PASARGUARD_DATA / "db.sqlite3")
+            db = sqlite3.connect(path)
+            try:
+                row = db.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+                    (table,),
+                ).fetchone()
+                return bool(row)
+            finally:
+                db.close()
+        if db_type in ("postgresql", "timescaledb"):
+            import psycopg2
+
+            with psycopg2.connect(
+                host=host, port=port, dbname=database, user=user, password=password,
+            ) as pg:
+                with pg.cursor() as cur:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema='public' AND table_name=%s LIMIT 1",
+                        (table_l,),
+                    )
+                    return bool(cur.fetchone())
+        import pymysql
+
+        with pymysql.connect(
+            host=host, port=port, user=user, password=password,
+            database=database, charset="utf8mb4",
+        ) as mysql:
+            with mysql.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema=%s AND table_name=%s LIMIT 1",
+                    (database, table),
+                )
+                return bool(cur.fetchone())
+    except Exception:
+        return False
+
+
+def write_alembic_version_on_conn(
+    db_type: str, conn: dict, version: str | None,
+) -> bool:
+    """Clear and optionally set alembic_version on a specific connection.
+
+    Used for intermediate/staging DBs so we never stamp the wrong compose service
+    or the live Marzban source when working on a pgmig_* copy.
+    """
+    host = conn.get("host") or "127.0.0.1"
+    port = int(migration_port(conn, db_type))
+    user = conn.get("user") or (
+        "postgres" if db_type in ("postgresql", "timescaledb") else "root"
+    )
+    password = conn.get("password") or ""
+    database = conn.get("database") or "pasarguard"
+    try:
+        if db_type == "sqlite":
+            path = Path(conn.get("sqlite_path") or PASARGUARD_DATA / "db.sqlite3")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            db = sqlite3.connect(str(path))
+            try:
+                db.execute(
+                    "CREATE TABLE IF NOT EXISTS alembic_version "
+                    "(version_num VARCHAR(32) NOT NULL)"
+                )
+                db.execute("DELETE FROM alembic_version")
+                if version:
+                    db.execute(
+                        "INSERT INTO alembic_version (version_num) VALUES (?)",
+                        (version,),
+                    )
+                db.commit()
+                return True
+            finally:
+                db.close()
+
+        if db_type in ("postgresql", "timescaledb"):
+            import psycopg2
+
+            with psycopg2.connect(
+                host=host, port=port, dbname=database, user=user, password=password,
+            ) as pg:
+                with pg.cursor() as cur:
+                    cur.execute(
+                        "CREATE TABLE IF NOT EXISTS alembic_version "
+                        "(version_num VARCHAR(32) NOT NULL)"
+                    )
+                    cur.execute("DELETE FROM alembic_version")
+                    if version:
+                        cur.execute(
+                            "INSERT INTO alembic_version (version_num) VALUES (%s)",
+                            (version,),
+                        )
+                pg.commit()
+            return True
+
+        import pymysql
+
+        with pymysql.connect(
+            host=host, port=port, user=user, password=password,
+            database=database, charset="utf8mb4", autocommit=True,
+        ) as mysql:
+            with mysql.cursor() as cur:
+                cur.execute(
+                    "CREATE TABLE IF NOT EXISTS alembic_version "
+                    "(version_num VARCHAR(32) NOT NULL)"
+                )
+                cur.execute("DELETE FROM alembic_version")
+                if version:
+                    cur.execute(
+                        "INSERT INTO alembic_version (version_num) VALUES (%s)",
+                        (version,),
+                    )
+        return True
+    except Exception:
+        return False
+
+
+async def _revision_known_to_pasarguard(migrator, revision: str) -> bool:
+    if not revision:
+        return False
+    ok, out = await _run_pasarguard_alembic(migrator, "show", revision)
+    text = (out or "").lower()
+    if "can't locate" in text or "no such revision" in text or "invalid revision key" in text:
+        return False
+    if ok or _alembic_output_indicates_success(out or ""):
+        return True
+    # Infra/docker noise — do not treat as missing
+    return True
+
+
+async def _pick_marzban_bridge_revision(migrator) -> str | None:
+    for rev in _MARZBAN_BRIDGE_REVISIONS:
+        if await _revision_known_to_pasarguard(migrator, rev):
+            return rev
+    # Prefer a deterministic fallback so staging heal still works if `alembic show` is flaky
+    return _MARZBAN_BRIDGE_REVISIONS[0] if _MARZBAN_BRIDGE_REVISIONS else None
+
+
+async def heal_unknown_alembic_revision(
+    migrator,
+    db_type: str,
+    conn: dict,
+    *,
+    missing_revision: str | None = None,
+) -> bool:
+    """Replace an unknown alembic stamp on staging/intermediate only.
+
+    Marzban-shaped (proxies present, groups absent): stamp just before PasarGuard
+    transform migrations so panel-boot can run proxies→inbounds/groups.
+    PasarGuard-shaped: stamp head.
+    """
+    if conn.get("_ephemeral_container") is None and conn.get("_allow_live_alembic_heal") is not True:
+        # Refuse to mutate a live source unless it is clearly a staging DB name.
+        db_name = str(conn.get("database") or "")
+        if not db_name.startswith("pgmig_") and db_type != "sqlite":
+            migrator.job.log(
+                "Refusing alembic heal on non-staging connection "
+                f"(db={db_name}) — live Marzban left untouched"
+            )
+            return False
+
+    label = missing_revision or "unknown"
+    has_proxies = _conn_table_exists(db_type, conn, "proxies")
+    has_groups = _conn_table_exists(db_type, conn, "groups")
+
+    if has_proxies and not has_groups:
+        bridge = await _pick_marzban_bridge_revision(migrator)
+        if not bridge:
+            migrator.job.log(
+                f"Unknown alembic revision {label} on Marzban-shaped DB, "
+                "but no bridge revision found in PasarGuard image"
+            )
+            return False
+        migrator.job.log(
+            f"Unknown alembic revision {label} — Marzban-shaped schema detected; "
+            f"stamping bridge {bridge} on staging (proxies→PasarGuard transforms)"
+        )
+        return write_alembic_version_on_conn(db_type, conn, bridge)
+
+    head = await get_alembic_head_revision(migrator)
+    if head:
+        migrator.job.log(
+            f"Unknown alembic revision {label} — stamping PasarGuard head {head} on staging"
+        )
+        return write_alembic_version_on_conn(db_type, conn, head)
+
+    migrator.job.log(
+        f"Unknown alembic revision {label} — clearing alembic_version on staging"
+    )
+    return write_alembic_version_on_conn(db_type, conn, None)
+
+
 async def run_alembic_upgrade_head(
-    migrator, *, url_override: str | None = None, heal_db: str | None = None,
+    migrator,
+    *,
+    url_override: str | None = None,
+    heal_db: str | None = None,
+    heal_conn: dict | None = None,
 ) -> None:
     """Upgrade schema to head only — never bootstrap to a source revision."""
     migrator.job.log("Alembic upgrade head...")
@@ -886,9 +1133,27 @@ async def run_alembic_upgrade_head(
     )
     if ok:
         return
+
+    if _is_missing_revision_error(out or "") and heal_db and heal_conn:
+        missing = _parse_missing_revision(out or "")
+        migrator.job.log(
+            f"Alembic missing revision {missing} — healing staging stamp..."
+        )
+        if await heal_unknown_alembic_revision(
+            migrator, heal_db, heal_conn, missing_revision=missing,
+        ):
+            ok2, out2 = await _run_pasarguard_alembic(
+                migrator, "upgrade", "head", url_override=url_override,
+            )
+            if ok2:
+                return
+            out = out2 or out
+
     if _is_duplicate_schema_error(out or "") and heal_db:
         migrator.job.log("Schema partially exists — healing alembic_version...")
-        if await _heal_alembic_duplicate_schema(migrator, heal_db, out or ""):
+        if await _heal_alembic_duplicate_schema(
+            migrator, heal_db, out or "", heal_conn=heal_conn,
+        ):
             ok2, out2 = await _run_pasarguard_alembic(
                 migrator, "upgrade", "head", url_override=url_override,
             )
@@ -912,35 +1177,31 @@ async def get_alembic_head_revision(migrator) -> str | None:
     return None
 
 
-def _parse_upgrade_target_revision(output: str) -> str | None:
-    m = re.search(r"Running upgrade\s+\S+\s*->\s*([0-9a-f]+)", output, re.I)
-    if m:
-        return m.group(1)
-    m = re.search(r"versions/([0-9a-f]+)_", output, re.I)
-    if m:
-        return m.group(1)
-    return None
-
-
-def _is_duplicate_schema_error(output: str) -> bool:
-    low = (output or "").lower()
-    return "duplicatecolumn" in low or "already exists" in low
-
-
-async def _heal_alembic_duplicate_schema(migrator, target_db: str, output: str) -> bool:
+async def _heal_alembic_duplicate_schema(
+    migrator, target_db: str, output: str, *, heal_conn: dict | None = None,
+) -> bool:
     """When schema already has migration changes but alembic_version lags, stamp the right revision."""
     target_rev = _parse_upgrade_target_revision(output)
     if not target_rev:
         target_rev = await get_alembic_head_revision(migrator)
     if target_rev:
         migrator.job.log(f"Healing alembic_version → {target_rev} (schema already migrated)")
-        if await set_target_alembic_version(migrator, target_db, target_rev):
+        if heal_conn is not None:
+            if write_alembic_version_on_conn(target_db, heal_conn, target_rev):
+                return True
+        elif await set_target_alembic_version(migrator, target_db, target_rev):
             return True
     migrator.job.log("Falling back to alembic stamp head...")
-    if await stamp_alembic_head(migrator):
+    if heal_conn is not None:
+        head = await get_alembic_head_revision(migrator)
+        if head and write_alembic_version_on_conn(target_db, heal_conn, head):
+            return True
+    elif await stamp_alembic_head(migrator):
         return True
     head = await get_alembic_head_revision(migrator)
     if head:
+        if heal_conn is not None:
+            return write_alembic_version_on_conn(target_db, heal_conn, head)
         return await set_target_alembic_version(migrator, target_db, head)
     return False
 

--- a/tests/test_migration_logic.py
+++ b/tests/test_migration_logic.py
@@ -204,6 +204,8 @@ def test_alembic_duplicate_heal_helpers():
     from app.services.pasarguard_ops import (
         _parse_upgrade_target_revision,
         _is_duplicate_schema_error,
+        _parse_missing_revision,
+        _is_missing_revision_error,
     )
     log = (
         "Running upgrade 931ed40d6eec -> 68edca039166, "
@@ -213,7 +215,93 @@ def test_alembic_duplicate_heal_helpers():
     assert _is_duplicate_schema_error(log) is True
     assert _is_duplicate_schema_error("column already exists") is True
     assert _is_duplicate_schema_error("ok") is False
-    print("OK: alembic duplicate heal helpers")
+
+    missing = (
+        "ERROR [alembic.util.messaging] Can't locate revision identified by '5b41f7d2e9a1'"
+    )
+    assert _parse_missing_revision(missing) == "5b41f7d2e9a1"
+    assert _is_missing_revision_error(missing) is True
+    assert _is_missing_revision_error(log) is False
+    print("OK: alembic duplicate/missing revision heal helpers")
+
+
+def test_write_alembic_version_on_sqlite_conn(tmp_path=None):
+    import tempfile
+    from pathlib import Path
+    from app.services.pasarguard_ops import (
+        write_alembic_version_on_conn,
+        read_sqlite_alembic_version,
+    )
+
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "db.sqlite3"
+        conn = {"sqlite_path": str(path), "_allow_live_alembic_heal": True}
+        assert write_alembic_version_on_conn("sqlite", conn, "5b41f7d2e9a1") is True
+        assert read_sqlite_alembic_version(path) == "5b41f7d2e9a1"
+        assert write_alembic_version_on_conn("sqlite", conn, "0b62f893092b") is True
+        assert read_sqlite_alembic_version(path) == "0b62f893092b"
+        assert write_alembic_version_on_conn("sqlite", conn, None) is True
+        assert read_sqlite_alembic_version(path) is None
+        print("OK: write_alembic_version_on_conn sqlite")
+
+
+def test_heal_unknown_refuses_live_mysql():
+    import asyncio
+    from unittest.mock import MagicMock
+    from app.services.pasarguard_ops import heal_unknown_alembic_revision
+
+    migrator = MagicMock()
+    migrator.job = MagicMock()
+    conn = {
+        "host": "127.0.0.1",
+        "port": 3306,
+        "user": "root",
+        "password": "x",
+        "database": "marzban",  # live Marzban — must not heal
+    }
+
+    async def _run():
+        return await heal_unknown_alembic_revision(
+            migrator, "mysql", conn, missing_revision="5b41f7d2e9a1",
+        )
+
+    assert asyncio.run(_run()) is False
+    print("OK: heal refuses live Marzban MySQL")
+
+
+def test_heal_unknown_marzban_shaped_sqlite(tmp_path=None):
+    import asyncio
+    import sqlite3
+    import tempfile
+    from pathlib import Path
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from app.services import pasarguard_ops as ops
+
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "db.sqlite3"
+        db = sqlite3.connect(str(path))
+        db.execute("CREATE TABLE proxies (id INTEGER PRIMARY KEY)")
+        db.execute("CREATE TABLE alembic_version (version_num VARCHAR(32))")
+        db.execute("INSERT INTO alembic_version VALUES ('5b41f7d2e9a1')")
+        db.commit()
+        db.close()
+
+        migrator = MagicMock()
+        migrator.job = MagicMock()
+        conn = {"sqlite_path": str(path), "_allow_live_alembic_heal": True}
+
+        async def _run():
+            with patch.object(
+                ops, "_pick_marzban_bridge_revision",
+                new=AsyncMock(return_value="0b62f893092b"),
+            ):
+                return await ops.heal_unknown_alembic_revision(
+                    migrator, "sqlite", conn, missing_revision="5b41f7d2e9a1",
+                )
+
+        assert asyncio.run(_run()) is True
+        assert ops.read_sqlite_alembic_version(path) == "0b62f893092b"
+        print("OK: heal Marzban-shaped sqlite stamps bridge")
 
 
 def test_build_local_alembic_url_from_ops():
@@ -282,6 +370,9 @@ if __name__ == "__main__":
     test_parse_sqlalchemy_urls()
     test_read_sqlite_alembic_version()
     test_alembic_duplicate_heal_helpers()
+    test_write_alembic_version_on_sqlite_conn()
+    test_heal_unknown_refuses_live_mysql()
+    test_heal_unknown_marzban_shaped_sqlite()
     test_build_local_alembic_url_from_ops()
     test_resolve_pasarguard_service()
     test_pasarguard_install_dbs()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes Marzban MySQL → TimescaleDB migration failing with:

`Can't locate revision identified by '5b41f7d2e9a1'`

That stamp exists in the Marzban dump but not in the PasarGuard alembic scripts.

## Approach
- Detect missing-revision Alembic errors
- Heal **only** on staging (`pgmig_*` / ephemeral / explicit allow) — **never** mutate live Marzban MySQL
- For Marzban-shaped schema (`proxies` present, no `groups`): stamp a bridge revision before PasarGuard transforms
- On the Marzban panel-boot path, skip host-network `alembic upgrade head` so transforms are not skipped early
- Same-family MySQL→MySQL path also heals the imported PasarGuard DB before panel boot

## Safety
Live Marzban MySQL is refused by the heal guard unless the DB name is `pgmig_*` or `_allow_live_alembic_heal` is set (staging / wiped target after dump import).

## Tests
- Unit coverage for parse/heal/refuse-live and Marzban-shaped SQLite bridge stamp
- `tests/test_migration_logic.py` passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcd68-024e-7c4b-a8bd-daaae7c1b4b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcd68-024e-7c4b-a8bd-daaae7c1b4b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

