### PR TITLE
Fix empty JSON on migrate start + block concurrent jobs (v2.0.5)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.0.4`** — Always take a full backup before restore or migration.
+> ⚠️ **`v2.0.5`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -55,6 +55,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v2.0.5 | Fix empty-JSON error on migrate start + block concurrent migrations (staging port races) |
 | v2.0.4 | Fix Marzban MySQL→Timescale when source alembic_version is missing from PasarGuard (staging-only heal) |
 | v2.0.3 | Fix Timescale restore: detect old chunk.schema_name catalog and pin image to 2.28.3 on 2.29+ hosts |
 | v2.0.2 | Fix MariaDB→Timescale migrate (ephemeral CREATE DATABASE + stage on mariadb:11) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v2.0.4`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v2.0.5`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -57,6 +57,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v2.0.5 | فیکس خطای JSON خالی هنگام شروع مهاجرت + جلوگیری از اجرای هم‌زمان (پورت staging) |
 | v2.0.4 | فیکس مهاجرت Marzban MySQL→Timescale وقتی alembic_version مرزبان در PasarGuard نیست (heal فقط روی staging) |
 | v2.0.3 | فیکس ریستور Timescale: تشخیص کاتالوگ قدیمی chunk.schema_name و پین ایمیج به 2.28.3 روی سرورهای 2.29+ |
 | v2.0.2 | فیکس مهاجرت MariaDB→Timescale (ساخت DB موقت + staging با mariadb:11) |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.0.4`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v2.0.5`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -55,6 +55,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v2.0.5 | Исправление пустого JSON при старте миграции + блокировка параллельных запусков |
 | v2.0.4 | Исправление миграции Marzban MySQL→Timescale при неизвестном alembic_version (heal только на staging) |
 | v2.0.3 | Исправление restore Timescale: детект старого каталога chunk.schema_name и pin образа на 2.28.3 для хостов 2.29+ |
 | v2.0.2 | Исправление миграции MariaDB→Timescale (CREATE DATABASE + staging на mariadb:11) |

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from app.panels import (
     OWNER_TEMP_KEY_CMD, SSH_TUNNEL_CMD, can_convert_databases,
 )
 from app.services.prerequisites import check_prerequisites, get_recommended_target_dbs, get_system_status
-from app.services.orchestrator import start_migration, get_job
+from app.services.orchestrator import start_migration, get_job, MigrationAlreadyRunning
 from app.services.validation import validate_migration
 from app.services.upload import save_upload, get_upload_path, get_upload_analysis
 from app.services.upload_bundle import (
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "2.0.4"
+APP_VERSION = "2.0.5"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"
@@ -262,7 +262,22 @@ async def api_migrate(req: MigrationRequest):
     if not validation["ok"]:
         raise HTTPException(400, {"errors": validation["errors"]})
 
-    job = await start_migration(params)
+    try:
+        job = await start_migration(params)
+    except MigrationAlreadyRunning as e:
+        raise HTTPException(
+            409,
+            {
+                "en": str(e),
+                "fa": (
+                    f"یک مهاجرت در حال اجرا است (job={e.job.job_id}، "
+                    f"{e.job.progress}٪). تا پایان صبر کنید؛ کلیک دوباره نکنید."
+                ),
+                "ru": str(e),
+                "job_id": e.job.job_id,
+                "progress": e.job.progress,
+            },
+        )
     return {"job_id": job.job_id, "status": job.status}
 
 

--- a/app/services/orchestrator.py
+++ b/app/services/orchestrator.py
@@ -27,11 +27,34 @@ def get_job(job_id: str) -> MigrationJob | None:
     return _active_jobs.get(job_id)
 
 
+def get_running_migration_job() -> MigrationJob | None:
+    """Return the in-flight job if any (pending/running)."""
+    for job in _active_jobs.values():
+        if job.status in ("pending", "running"):
+            return job
+    return None
+
+
+class MigrationAlreadyRunning(RuntimeError):
+    """Raised when a second migrate is requested while one is active."""
+
+    def __init__(self, job: MigrationJob):
+        self.job = job
+        super().__init__(
+            f"A migration is already running (job_id={job.job_id}, "
+            f"progress={job.progress}%). Wait for it to finish before starting another."
+        )
+
+
 async def start_migration(params: dict, on_log: Callable | None = None) -> MigrationJob:
     panel = params.get("source_panel")
     migrator_cls = MIGRATORS.get(panel)
     if not migrator_cls:
         raise ValueError(f"Unsupported panel: {panel}")
+
+    existing = get_running_migration_job()
+    if existing:
+        raise MigrationAlreadyRunning(existing)
 
     job = MigrationJob()
     _active_jobs[job.job_id] = job

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -444,7 +444,7 @@ async function fetchJson(url, opts = {}, { retries = 2, timeoutMs = 20000 } = {}
     try {
       const res = await fetch(url, { ...opts, signal: ctrl?.signal });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      return await res.json();
+      return await parseResponseJson(res);
     } catch (e) {
       lastErr = e;
       if (attempt < retries) await new Promise(r => setTimeout(r, 400 * (attempt + 1)));
@@ -453,6 +453,26 @@ async function fetchJson(url, opts = {}, { retries = 2, timeoutMs = 20000 } = {}
     }
   }
   throw lastErr || new Error('fetch failed');
+}
+
+/** Parse JSON body safely — empty/truncated responses become a clear Error. */
+async function parseResponseJson(res) {
+  const text = await res.text();
+  if (!text || !String(text).trim()) {
+    throw new Error(
+      `Empty response from server (HTTP ${res.status}). `
+      + 'Migration was not started — check pg-migrator is running, then retry once. '
+      + `/ پاسخ خالی از سرور (HTTP ${res.status}). مهاجرت شروع نشده؛ سرویس را چک کنید و فقط یک‌بار دوباره بزنید.`,
+    );
+  }
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    const snippet = String(text).replace(/\s+/g, ' ').slice(0, 160);
+    throw new Error(
+      `Invalid JSON from server (HTTP ${res.status}): ${snippet}`,
+    );
+  }
 }
 
 function applySystemCheck(sys) {
@@ -691,7 +711,16 @@ async function validateMigrationRequest() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    return await res.json();
+    const data = await parseResponseJson(res);
+    if (!res.ok) {
+      return {
+        ok: false,
+        errors: data?.detail?.errors || data?.errors || [
+          { en: data?.detail || `HTTP ${res.status}`, fa: data?.detail || `HTTP ${res.status}`, ru: data?.detail || `HTTP ${res.status}` },
+        ],
+      };
+    }
+    return data;
   } catch (e) {
     return { ok: false, errors: [{ en: e.message, fa: e.message, ru: e.message }] };
   }
@@ -965,36 +994,60 @@ function renderSummary() {
 }
 
 async function startMigration() {
-  const v = await validateMigrationRequest();
-  if (!v.ok) {
-    showStepBlock(4, tr(v.errors[0], state.lang) || t('block.validationFailed'));
-    return;
-  }
-
-  await goStep(5);
-  const terminal = document.getElementById('logTerminal');
-  terminal.textContent = '';
-  if (typeof resetUiProgress === 'function') resetUiProgress('_migrateUiProgress');
-  const fill = document.getElementById('progressFill');
-  const text = document.getElementById('progressText');
-  if (fill) fill.style.width = '0%';
-  if (text) text.textContent = '0%';
-
-  const body = buildMigrationBody();
+  const btn = document.getElementById('btnStep4');
+  if (state._migrateStarting) return;
+  state._migrateStarting = true;
+  if (btn) btn.disabled = true;
 
   try {
-    const res = await fetch('/api/migrate', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-    if (!res.ok) {
-      const err = await res.json();
-      const msg = err.detail?.errors?.[0] ? tr(err.detail.errors[0], state.lang) : (err.detail || res.statusText);
-      showError(msg);
+    const v = await validateMigrationRequest();
+    if (!v.ok) {
+      showStepBlock(4, tr(v.errors[0], state.lang) || t('block.validationFailed'));
       return;
     }
-    const data = await res.json();
+
+    await goStep(5);
+    const terminal = document.getElementById('logTerminal');
+    terminal.textContent = '';
+    if (typeof resetUiProgress === 'function') resetUiProgress('_migrateUiProgress');
+    const fill = document.getElementById('progressFill');
+    const text = document.getElementById('progressText');
+    if (fill) fill.style.width = '0%';
+    if (text) text.textContent = '0%';
+
+    const body = buildMigrationBody();
+
+    const res = await fetch('/api/migrate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    let data;
+    try {
+      data = await parseResponseJson(res);
+    } catch (e) {
+      // Still on step 5 — show clear message; job was not started without job_id
+      showError(e.message);
+      return;
+    }
+    if (!res.ok) {
+      const d = data?.detail;
+      let msg;
+      if (d?.errors?.[0]) msg = tr(d.errors[0], state.lang);
+      else if (d && typeof d === 'object' && (d.fa || d.en)) msg = tr(d, state.lang) || d.en || d.fa;
+      else if (typeof d === 'string') msg = d;
+      else msg = res.statusText;
+      showError(typeof msg === 'string' ? msg : JSON.stringify(msg));
+      return;
+    }
     state.jobId = data.job_id;
     connectWebSocket(data.job_id);
   } catch (e) {
     showError(e.message);
+  } finally {
+    state._migrateStarting = false;
+    // Re-enable only if we never left confirmation (validation failed)
+    if (btn && state.currentStep === 4) btn.disabled = false;
   }
 }
 

--- a/tests/test_orchestrator_concurrency.py
+++ b/tests/test_orchestrator_concurrency.py
@@ -1,0 +1,78 @@
+"""Concurrent migration guard."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from app.services.orchestrator import (
+    MigrationAlreadyRunning,
+    _active_jobs,
+    get_running_migration_job,
+    start_migration,
+)
+from app.services.migrators.base import MigrationJob
+
+
+def setup_function():
+    _active_jobs.clear()
+
+
+def teardown_function():
+    _active_jobs.clear()
+
+
+def test_get_running_migration_job():
+    j = MigrationJob(job_id="abc")
+    j.status = "running"
+    _active_jobs[j.job_id] = j
+    assert get_running_migration_job() is j
+    j.status = "success"
+    assert get_running_migration_job() is None
+    print("OK: get_running_migration_job")
+
+
+def test_start_migration_rejects_second_job():
+    async def _run():
+        class FakeMigrator:
+            def __init__(self, job, params):
+                self.job = job
+
+            async def run(self, params):
+                await asyncio.sleep(0.05)
+                return {"ok": True}
+
+        with patch.dict(
+            "app.services.orchestrator.MIGRATORS",
+            {"marzban": FakeMigrator},
+            clear=False,
+        ):
+            job1 = await start_migration({"source_panel": "marzban"})
+            try:
+                await start_migration({"source_panel": "marzban"})
+                raise AssertionError("expected MigrationAlreadyRunning")
+            except MigrationAlreadyRunning as e:
+                assert e.job.job_id == job1.job_id
+            # Let first finish
+            for _ in range(50):
+                if job1.status in ("success", "error"):
+                    break
+                await asyncio.sleep(0.02)
+            assert job1.status == "success"
+            job2 = await start_migration({"source_panel": "marzban"})
+            assert job2.job_id != job1.job_id
+            for _ in range(50):
+                if job2.status in ("success", "error"):
+                    break
+                await asyncio.sleep(0.02)
+
+    asyncio.run(_run())
+    print("OK: start_migration rejects concurrent job")
+
+
+if __name__ == "__main__":
+    setup_function()
+    test_get_running_migration_job()
+    teardown_function()
+    setup_function()
+    test_start_migration_rejects_second_job()
+    teardown_function()
+    print("\nAll orchestrator concurrency tests passed.")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The confirmation-step error `Failed to execute 'json' on 'Response': Unexpected end of JSON input` comes from the UI calling `res.json()` on an **empty** `/api/validate-migration` body. In that case migration was **not** started yet.

## Changes
- Safe JSON parsing with a clear EN/FA message (migration not started)
- Disable Start button while a start is in flight (no double-click)
- Backend rejects a second concurrent migration (HTTP 409) to avoid ephemeral MySQL staging port races (33060)

## Upgrade
```bash
sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcd68-024e-7c4b-a8bd-daaae7c1b4b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcd68-024e-7c4b-a8bd-daaae7c1b4b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

