### PR TITLE
Fix 3x-ui modern migrate: 'int' object has no attribute 'strip'

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.2`** — Always take a full backup before restore or migration.
+> ⚠️ **`v2.2.3`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -56,6 +56,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v2.2.3 | Fix modern 3x-ui migrate crash on empty uuid + integer clients.id |
 | v2.2.2 | Free Hiddify port 443 so pg-redirect can bind |
 | v2.2.1 | Post-migrate owner guide + clearer Hiddify partial warning |
 | v2.2.0 | Rewrite Hiddify migrate: hiddify-test group + PYTHONPATH=/code + redirect like 3x-ui |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v2.2.2`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v2.2.3`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -58,6 +58,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v2.2.3 | فیکس کرش مهاجرت 3x-ui مدرن: uuid خالی + clients.id عددی |
 | v2.2.2 | آزادسازی پورت ۴۴۳ هیدیفای برای pg-redirect |
 | v2.2.1 | راهنمای ساخت Owner + توضیح پیام مهاجرت ناقص هیدیفای |
 | v2.2.0 | بازنویسی مهاجرت هیدیفای: گروه hiddify-test + PYTHONPATH=/code + ریدایرکت مثل 3x-ui |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.2`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v2.2.3`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -56,6 +56,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v2.2.3 | Исправление краша миграции modern 3x-ui: пустой uuid + числовой clients.id |
 | v2.2.2 | Освобождение порта 443 Hiddify для pg-redirect |
 | v2.2.1 | Гайд owner после миграции + ясное предупреждение Hiddify |
 | v2.2.0 | Переписывание миграции Hiddify: группа hiddify-test + PYTHONPATH=/code + redirect как 3x-ui |

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "2.2.2"
+APP_VERSION = "2.2.3"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/services/migrators/xui.py
+++ b/app/services/migrators/xui.py
@@ -238,11 +238,25 @@ def is_modern_xui_multi_inbound_schema(path: Path) -> bool:
     return bool(detect_xui_db_schema(path).get("modern"))
 
 
+def _client_text(value) -> str:
+    """Coerce a clients-row field to stripped text.
+
+    Modern 3x-ui ``clients.id`` is an integer PK. Never treat ints/bools as
+    UUID/password/email strings — ``(… or id).strip()`` raises AttributeError.
+    Classic ``settings.clients[].id`` remains a UUID string and still works.
+    """
+    if value is None or isinstance(value, bool):
+        return ""
+    if isinstance(value, (int, float)):
+        return ""
+    return str(value).strip()
+
+
 def _client_entry_for_protocol(protocol: str, client: dict, flow_override: str = "") -> dict:
     """Build a classic ``settings.clients[]`` entry from a ``clients`` row."""
-    email = (client.get("email") or "").strip()
-    sub_id = (client.get("sub_id") or client.get("subId") or "").strip()
-    flow = (flow_override or client.get("flow") or "").strip()
+    email = _client_text(client.get("email"))
+    sub_id = _client_text(client.get("sub_id")) or _client_text(client.get("subId"))
+    flow = _client_text(flow_override) or _client_text(client.get("flow"))
     entry: dict = {
         "email": email,
         "enable": bool(client.get("enable", 1)),
@@ -256,8 +270,9 @@ def _client_entry_for_protocol(protocol: str, client: dict, flow_override: str =
         "security": str(client.get("security") or "auto"),
     }
     proto = (protocol or "").lower()
-    uuid = (client.get("uuid") or client.get("id") or "").strip()
-    password = (client.get("password") or "").strip()
+    # Prefer uuid column; fall back to string id only (classic JSON), never int PK.
+    uuid = _client_text(client.get("uuid")) or _client_text(client.get("id"))
+    password = _client_text(client.get("password"))
     if proto in ("vless", "vmess", "tunnel"):
         if uuid:
             entry["id"] = uuid
@@ -267,7 +282,7 @@ def _client_entry_for_protocol(protocol: str, client: dict, flow_override: str =
     if proto == "vless":
         entry["flow"] = flow
         # Keep auth if present (some panels store it); harmless for PG converter.
-        auth = (client.get("auth") or "").strip()
+        auth = _client_text(client.get("auth"))
         if auth:
             entry["auth"] = auth
     if proto == "vmess" and password and "id" not in entry:

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=2.2.2">
+  <link rel="stylesheet" href="/static/css/style.css?v=2.2.3">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v2.2.2</p>
+          <p class="header-version" id="appVersion">v2.2.3</p>
         </div>
       </div>
       <div class="header-meta">
@@ -579,8 +579,8 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=2.2.2"></script>
-  <script src="/static/js/app.js?v=2.2.2"></script>
+  <script src="/static/js/i18n.js?v=2.2.3"></script>
+  <script src="/static/js/app.js?v=2.2.3"></script>
   <script src="/static/js/wizard-flow.js?v=1.1beta.13"></script>
 </body>
 </html>

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="2.2.2"
+readonly SCRIPT_VERSION="2.2.3"
 readonly INSTALL_DIR="/opt/pg-migrator"
 readonly SERVICE_NAME="pg-migrator"
 readonly WEB_PORT=7000

--- a/tests/test_xui_modern_schema.py
+++ b/tests/test_xui_modern_schema.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from app.services.migrators.xui import (
+    _client_entry_for_protocol,
     detect_xui_db_schema,
     ensure_sudo_admin_from_xui,
     is_modern_xui_multi_inbound_schema,
@@ -264,5 +265,112 @@ def test_seed_hosts_and_admin_for_modern():
                 assert tag.startswith("in-")
                 assert alpn != "none"  # EnumArray-breaking value
             assert conn.execute("SELECT COUNT(*) FROM admins").fetchone()[0] == 1
+        finally:
+            conn.close()
+
+
+def test_client_entry_ignores_integer_pk_as_uuid():
+    """Modern clients.id is int PK — must not call .strip() on it (regression)."""
+    row = {
+        "id": 7,
+        "uuid": None,
+        "email": "user1",
+        "sub_id": "abc123",
+        "enable": 1,
+        "expiry_time": 0,
+        "total_gb": 0,
+        "limit_ip": 0,
+        "password": "",
+        "flow": "",
+    }
+    entry = _client_entry_for_protocol("vless", row)
+    assert entry["email"] == "user1"
+    assert "id" not in entry  # no uuid available; int PK must not become id
+
+    row["uuid"] = "f9d010f5-5812-487b-a2b4-3705b9f69dbb"
+    entry = _client_entry_for_protocol("vless", row)
+    assert entry["id"] == "f9d010f5-5812-487b-a2b4-3705b9f69dbb"
+
+    # Classic settings.clients[] uses string id as UUID
+    classic = {"id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "email": "c1"}
+    assert _client_entry_for_protocol("vmess", classic)["id"] == (
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    )
+
+
+def test_normalize_modern_with_null_uuid_does_not_crash():
+    """Reproduce AttributeError: 'int' object has no attribute 'strip'."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "x-ui.db"
+        conn = sqlite3.connect(db)
+        conn.executescript(
+            """
+            CREATE TABLE clients (
+                id INTEGER PRIMARY KEY,
+                email TEXT,
+                uuid TEXT,
+                sub_id TEXT,
+                enable INTEGER DEFAULT 1,
+                expiry_time INTEGER DEFAULT 0,
+                total_gb INTEGER DEFAULT 0,
+                limit_ip INTEGER DEFAULT 0,
+                password TEXT,
+                flow TEXT,
+                tg_id TEXT,
+                comment TEXT,
+                reset INTEGER DEFAULT 0,
+                security TEXT
+            );
+            CREATE TABLE client_inbounds (
+                id INTEGER PRIMARY KEY,
+                client_id INTEGER,
+                inbound_id INTEGER,
+                flow_override TEXT
+            );
+            CREATE TABLE client_traffics (
+                id INTEGER PRIMARY KEY,
+                inbound_id INTEGER,
+                enable NUMERIC,
+                email TEXT UNIQUE,
+                up INTEGER, down INTEGER,
+                expiry_time INTEGER, total INTEGER,
+                reset INTEGER DEFAULT 0
+            );
+            CREATE TABLE inbounds (
+                id INTEGER PRIMARY KEY,
+                protocol TEXT,
+                settings TEXT
+            );
+            INSERT INTO clients (id, email, uuid, sub_id, enable)
+            VALUES (1, 'u1', NULL, 'sub1', 1),
+                   (2, 'u2', '', 'sub2', 1),
+                   (3, 'u3', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', 'sub3', 1);
+            INSERT INTO client_inbounds (client_id, inbound_id) VALUES
+                (1, 1), (2, 1), (3, 1);
+            INSERT INTO client_traffics (inbound_id, enable, email, up, down, expiry_time, total)
+            VALUES (1, 1, 'u1', 0, 0, 0, 0),
+                   (1, 1, 'u2', 0, 0, 0, 0),
+                   (1, 1, 'u3', 0, 0, 0, 0);
+            INSERT INTO inbounds (id, protocol, settings)
+            VALUES (1, 'vless', '{"clients":[]}');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        stats = normalize_modern_xui_sqlite(db)
+        assert stats["normalized"] is True
+
+        conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+        try:
+            settings = json.loads(
+                conn.execute("SELECT settings FROM inbounds WHERE id=1").fetchone()[0]
+            )
+            clients = settings["clients"]
+            assert len(clients) == 3
+            by_email = {c["email"]: c for c in clients}
+            assert "id" not in by_email["u1"]
+            assert "id" not in by_email["u2"]
+            assert by_email["u3"]["id"] == "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
         finally:
             conn.close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cause

In modern 3x-ui schema, `clients.id` is an **integer primary key**, while the protocol UUID lives in `clients.uuid`.

During `normalize_modern_xui_sqlite`, `_client_entry_for_protocol` did:

```python
uuid = (client.get("uuid") or client.get("id") or "").strip()
```

When `uuid` was `NULL` or empty, it fell back to the integer PK and called `.strip()` → `AttributeError: 'int' object has no attribute 'strip'`.

## Fix

- Add `_client_text()` that safely coerces fields and ignores ints/bools
- Prefer `uuid`; only fall back to `id` when it is a string (classic JSON clients)
- Never treat the integer PK as a VLESS/VMess id
- Regression tests for null/empty uuid rows
- Version bump to **2.2.3**

## Test plan

- [x] `test_client_entry_ignores_integer_pk_as_uuid`
- [x] `test_normalize_modern_with_null_uuid_does_not_crash`
- [ ] Re-run the failing real 3x-ui upload migration after deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd269-f616-73d7-abd8-de1c2aab6409?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd269-f616-73d7-abd8-de1c2aab6409&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

