### PR TITLE
Release v2.2.4: fix PASARGUARD_ENV NameError in Marzban cross-DB migrate

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -56,6 +56,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v2.2.4 | Fix Marzban cross-DB migrate NameError: missing PASARGUARD_ENV import in panel-boot |
 | v2.2.3 | Fix modern 3x-ui migrate crash on empty uuid + integer clients.id |
 | v2.2.2 | Free Hiddify port 443 so pg-redirect can bind |
 | v2.2.1 | Post-migrate owner guide + clearer Hiddify partial warning |

--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.3`** — Always take a full backup before restore or migration.
+> ⚠️ **`v2.2.4`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v2.2.3`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v2.2.4`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -58,6 +58,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v2.2.4 | فیکس NameError مهاجرت Marzban cross-DB: import جاافتاده PASARGUARD_ENV در panel-boot |
 | v2.2.3 | فیکس کرش مهاجرت 3x-ui مدرن: uuid خالی + clients.id عددی |
 | v2.2.2 | آزادسازی پورت ۴۴۳ هیدیفای برای pg-redirect |
 | v2.2.1 | راهنمای ساخت Owner + توضیح پیام مهاجرت ناقص هیدیفای |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.3`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v2.2.4`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -56,6 +56,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v2.2.4 | Исправление NameError миграции Marzban cross-DB: отсутствовал import PASARGUARD_ENV в panel-boot |
 | v2.2.3 | Исправление краша миграции modern 3x-ui: пустой uuid + числовой clients.id |
 | v2.2.2 | Освобождение порта 443 Hiddify для pg-redirect |
 | v2.2.1 | Гайд owner после миграции + ясное предупреждение Hiddify |

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "2.2.3"
+APP_VERSION = "2.2.4"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/services/native_migration/cross_db.py
+++ b/app/services/native_migration/cross_db.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-from app.config import PASARGUARD_DIR, PASARGUARD_DATA, BACKUP_DIR
+from app.config import PASARGUARD_DIR, PASARGUARD_DATA, PASARGUARD_ENV, BACKUP_DIR
 from app.services.db_credentials import get_source_connection, get_target_connection
 from app.services.pasarguard_ops import (
     docker_compose_up,

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=2.2.3">
+  <link rel="stylesheet" href="/static/css/style.css?v=2.2.4">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v2.2.3</p>
+          <p class="header-version" id="appVersion">v2.2.4</p>
         </div>
       </div>
       <div class="header-meta">
@@ -579,8 +579,8 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=2.2.3"></script>
-  <script src="/static/js/app.js?v=2.2.3"></script>
+  <script src="/static/js/i18n.js?v=2.2.4"></script>
+  <script src="/static/js/app.js?v=2.2.4"></script>
   <script src="/static/js/wizard-flow.js?v=1.1beta.13"></script>
 </body>
 </html>

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="2.2.3"
+readonly SCRIPT_VERSION="2.2.4"
 readonly INSTALL_DIR="/opt/pg-migrator"
 readonly SERVICE_NAME="pg-migrator"
 readonly WEB_PORT=7000

--- a/tests/test_native_migration.py
+++ b/tests/test_native_migration.py
@@ -1046,6 +1046,15 @@ def test_native_migration_import():
     print("OK: native migration imports")
 
 
+def test_cross_db_has_pasarguard_env():
+    """Regression: panel-boot upgrade references PASARGUARD_ENV at module scope."""
+    from app.config import PASARGUARD_ENV
+    from app.services.native_migration import cross_db
+
+    assert getattr(cross_db, "PASARGUARD_ENV", None) is PASARGUARD_ENV
+    print("OK: cross_db PASARGUARD_ENV import")
+
+
 if __name__ == "__main__":
     test_build_local_alembic_url()
     test_sqlite_column_intersection()
@@ -1069,4 +1078,5 @@ if __name__ == "__main__":
     test_prepare_replace_blocks_cascade_wipe()
     test_sanitize_env_text_for_docker()
     test_native_migration_import()
+    test_cross_db_has_pasarguard_env()
     print("\nAll native migration tests passed.")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Release **v2.2.4** — fixes `name 'PASARGUARD_ENV' is not defined` during Marzban cross-DB migration (panel-boot path).

## Cause
`_panel_boot_upgrade_intermediate` referenced `PASARGUARD_ENV` without importing it. Most migrations never hit `upgrade_via_panel=True`, so the bug was rare.

## Changes
- Import `PASARGUARD_ENV` in `cross_db.py`
- Regression test for the module export
- Version bump to **2.2.4** (`main.py`, `install.sh`, UI cache-bust, READMEs)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd40a-72f5-793f-a680-1beeec7b1e70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd40a-72f5-793f-a680-1beeec7b1e70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

