### PR TITLE
Fix MySQL restore heal when root password no longer matches .env

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.4`** — Always take a full backup before restore or migration.
+> ⚠️ **`v2.2.5`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -56,6 +56,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v2.2.5 | Fix MySQL restore heal when root password in the volume no longer matches .env (try all candidates, then safe skip-grant recovery on the same volume) |
 | v2.2.4 | Fix Marzban cross-DB migrate NameError: missing PASARGUARD_ENV import in panel-boot |
 | v2.2.3 | Fix modern 3x-ui migrate crash on empty uuid + integer clients.id |
 | v2.2.2 | Free Hiddify port 443 so pg-redirect can bind |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v2.2.4`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v2.2.5`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -58,6 +58,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v2.2.5 | فیکس heal ریستور MySQL وقتی رمز root داخل volume با .env یکی نیست (امتحان همهٔ کاندیداها، بعد recovery امن skip-grant روی همان volume) |
 | v2.2.4 | فیکس NameError مهاجرت Marzban cross-DB: import جاافتاده PASARGUARD_ENV در panel-boot |
 | v2.2.3 | فیکس کرش مهاجرت 3x-ui مدرن: uuid خالی + clients.id عددی |
 | v2.2.2 | آزادسازی پورت ۴۴۳ هیدیفای برای pg-redirect |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.4`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v2.2.5`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -56,6 +56,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v2.2.5 | Исправление heal restore MySQL, когда пароль root в volume не совпадает с .env (все кандидаты, затем безопасный skip-grant recovery на том же volume) |
 | v2.2.4 | Исправление NameError миграции Marzban cross-DB: отсутствовал import PASARGUARD_ENV в panel-boot |
 | v2.2.3 | Исправление краша миграции modern 3x-ui: пустой uuid + числовой clients.id |
 | v2.2.2 | Освобождение порта 443 Hiddify для pg-redirect |

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "2.2.4"
+APP_VERSION = "2.2.5"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/services/db_auth.py
+++ b/app/services/db_auth.py
@@ -239,6 +239,199 @@ def _mysql_client_bins(db_type: str, service: str | None = None) -> list[str]:
     return mysql_client_bins(db_type, service)
 
 
+def _mysql_sql_literal(password: str) -> str:
+    return (password or "").replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _mysql_ident(name: str) -> str:
+    """Quote a MySQL identifier (database / user) safely for generated SQL."""
+    return "`" + (name or "").replace("`", "``") + "`"
+
+
+def build_mysql_role_password_sql(
+    password: str,
+    app_user: str | None = None,
+    db_name: str | None = None,
+    *,
+    include_flush_first: bool = False,
+) -> str:
+    """SQL to align root + app user passwords for %, localhost, and 127.0.0.1.
+
+    Panel traffic often uses TCP to 127.0.0.1 (distinct from localhost socket).
+    CREATE USER IF NOT EXISTS keeps the statement safe when a host row is missing.
+    """
+    lit = _mysql_sql_literal(password)
+    hosts = ("%", "localhost", "127.0.0.1")
+    statements: list[str] = []
+    if include_flush_first:
+        # Required before ALTER USER while mysqld runs with --skip-grant-tables.
+        statements.append("FLUSH PRIVILEGES;")
+    for host in hosts:
+        statements.append(f"CREATE USER IF NOT EXISTS 'root'@'{host}' IDENTIFIED BY '{lit}';")
+        statements.append(f"ALTER USER 'root'@'{host}' IDENTIFIED BY '{lit}';")
+    user = (app_user or "").strip()
+    if user and user != "root":
+        for host in hosts:
+            statements.append(
+                f"CREATE USER IF NOT EXISTS '{user}'@'{host}' IDENTIFIED BY '{lit}';"
+            )
+            statements.append(f"ALTER USER '{user}'@'{host}' IDENTIFIED BY '{lit}';")
+        db = (db_name or "").strip() or "pasarguard"
+        db_q = _mysql_ident(db)
+        for host in hosts:
+            statements.append(
+                f"GRANT ALL PRIVILEGES ON {db_q}.* TO '{user}'@'{host}';"
+            )
+    statements.append("FLUSH PRIVILEGES;")
+    return " ".join(statements)
+
+
+def mysql_sync_auth_candidates(
+    *extra: str | None,
+    env_text: str | None = None,
+) -> list[str]:
+    """Passwords to try when authenticating as root for a role sync."""
+    text = env_text if env_text is not None else read_env_text()
+    return _unique_strings(*extra, *mysql_password_candidates(text))
+
+
+async def recover_mysql_passwords_via_skip_grants(
+    run_cmd,
+    *,
+    service: str,
+    password: str,
+    app_user: str,
+    db_type: str,
+    db_name: str = "pasarguard",
+    compose_cwd: str | None = None,
+    log=None,
+) -> bool:
+    """Last-resort password reset when root auth is unknown.
+
+    Stops the compose DB service, starts a temporary sibling container on the
+    *same data volume* with ``--skip-grant-tables --skip-networking``, sets
+    passwords, then brings the normal service back. Does not delete volumes.
+    """
+    import asyncio
+
+    if not password or not service:
+        return False
+
+    cwd = compose_cwd or str(PASARGUARD_DIR)
+    heal_name = f"pasarguard-{service}-pwd-heal"
+    bins = _mysql_client_bins(db_type, service)
+    sql = build_mysql_role_password_sql(
+        password, app_user=app_user, db_name=db_name, include_flush_first=True,
+    )
+
+    def _log(msg: str) -> None:
+        if log:
+            log(msg)
+
+    async def _run(cmd: list[str], timeout: int = 120) -> tuple[bool, str]:
+        return await run_cmd(cmd, cwd=cwd, timeout=timeout)
+
+    _log(
+        f"MySQL root locked out on {service} — temporary skip-grant recovery "
+        "(same volume, no data wipe)..."
+    )
+
+    # Drop leftover heal container from a previous interrupted run.
+    await _run(["docker", "rm", "-f", heal_name], timeout=60)
+    # Stop the normal service so the volume is free for the heal container.
+    stop_ok, stop_out = await _run(
+        ["docker", "compose", "stop", service], timeout=120
+    )
+    if not stop_ok:
+        _log(f"MySQL recover: could not stop {service}: {(stop_out or '')[-200:]}")
+        # Still try — volume may already be idle.
+    started = False
+    success = False
+    try:
+        # Keep docker-entrypoint.sh (do not override entrypoint) so existing
+        # datadir startup stays identical to a normal boot; only add mysqld flags.
+        run_ok, run_out = await _run(
+            [
+                "docker", "compose", "run", "-d", "--no-deps",
+                "--name", heal_name,
+                service,
+                "--skip-grant-tables", "--skip-networking",
+            ],
+            timeout=180,
+        )
+        if not run_ok:
+            _log(f"MySQL recover: compose run failed: {(run_out or '')[-300:]}")
+            return False
+        started = True
+
+        ready = False
+        ready_bin = bins[0]
+        for _ in range(40):
+            await asyncio.sleep(2)
+            for bin_name in bins:
+                ok, out = await _run(
+                    [
+                        "docker", "exec", heal_name, bin_name,
+                        "-u", "root", "-N", "-e", "SELECT 1",
+                    ],
+                    timeout=20,
+                )
+                if ok and "1" in (out or ""):
+                    ready = True
+                    ready_bin = bin_name
+                    break
+            if ready:
+                break
+        if not ready:
+            _log("MySQL recover: heal container never accepted root connections")
+            return False
+
+        ok, out = await _run(
+            [
+                "docker", "exec", heal_name, ready_bin,
+                "-u", "root", "-e", sql,
+            ],
+            timeout=60,
+        )
+        if not ok:
+            _log(f"MySQL recover: ALTER/CREATE failed: {(out or '')[-300:]}")
+            return False
+        _log(f"MySQL recover: passwords set via skip-grant ({ready_bin})")
+        success = True
+        return True
+    finally:
+        if started:
+            await _run(["docker", "stop", heal_name], timeout=60)
+        await _run(["docker", "rm", "-f", heal_name], timeout=60)
+        # Always restore the normal DB service — even if ALTER failed.
+        up_ok, up_out = await _run(
+            ["docker", "compose", "up", "-d", service], timeout=180
+        )
+        if not up_ok:
+            _log(f"MySQL recover: failed to restart {service}: {(up_out or '')[-300:]}")
+        elif success:
+            # Wait until normal mysqld accepts the new password before callers proceed.
+            for _ in range(30):
+                await asyncio.sleep(2)
+                verified = False
+                for bin_name in bins:
+                    ok, out = await _run(
+                        [
+                            "docker", "compose", "exec", "-T",
+                            "-e", f"MYSQL_PWD={password}",
+                            service, bin_name,
+                            "-u", "root", "-N", "-e", "SELECT 1",
+                        ],
+                        timeout=20,
+                    )
+                    if ok and "1" in (out or ""):
+                        verified = True
+                        break
+                if verified:
+                    _log(f"MySQL recover: {service} accepting new root password")
+                    break
+
+
 async def sync_mysql_roles_to_password(
     migrator,
     db_type: str,
@@ -247,12 +440,17 @@ async def sync_mysql_roles_to_password(
     app_user: str | None = None,
     password: str | None = None,
     env_text: str | None = None,
-) -> None:
+    db_name: str | None = None,
+    allow_skip_grant_recovery: bool = True,
+) -> bool:
     """Align MySQL/MariaDB root + app-user passwords so the panel URL can connect.
 
     Cross-DB copy authenticates as root; the panel uses DB_USER (often ``pasarguard``).
     Without this sync, ``Access denied for user 'pasarguard'@...`` is common after
     sqlite→mysql convert (same heal used by PasarGuard restore).
+
+    Tries every known password candidate first. Only if root is fully unreachable
+    does it fall back to temporary ``--skip-grant-tables`` recovery (same volume).
     """
     text = env_text if env_text is not None else read_env_text()
     service = resolve_db_service(db_type) or ("mariadb" if db_type == "mariadb" else "mysql")
@@ -265,7 +463,7 @@ async def sync_mysql_roles_to_password(
         or admin_pwd
     )
     if not new_pwd or not service:
-        return
+        return False
 
     user = (
         app_user
@@ -273,23 +471,21 @@ async def sync_mysql_roles_to_password(
         or read_env_var(text, "MYSQL_USER")
         or "pasarguard"
     )
-    lit = new_pwd.replace("\\", "\\\\").replace("'", "\\'")
-    statements = [
-        f"ALTER USER 'root'@'%' IDENTIFIED BY '{lit}';",
-        f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{lit}';",
-    ]
-    if user and user != "root":
-        statements.append(f"ALTER USER '{user}'@'%' IDENTIFIED BY '{lit}';")
-        statements.append(f"ALTER USER '{user}'@'localhost' IDENTIFIED BY '{lit}';")
-    statements.append("FLUSH PRIVILEGES;")
-    sql = " ".join(statements)
+    schema = (
+        db_name
+        or (admin_conn or {}).get("database")
+        or target_database_name(text, db_type)
+        or "pasarguard"
+    )
+    sql = build_mysql_role_password_sql(new_pwd, app_user=user, db_name=schema)
     cwd = str(PASARGUARD_DIR)
-    auth_pwds = _unique_strings(admin_pwd, new_pwd)
+    auth_pwds = mysql_sync_auth_candidates(admin_pwd, new_pwd, env_text=text)
     migrator.job.log(
-        f"Syncing MySQL passwords on {service} (app user={user})..."
+        f"Syncing MySQL passwords on {service} (app user={user}, "
+        f"auth candidates={len(auth_pwds)})..."
     )
     last_out = ""
-    # Use single-quoted -e payload so SQL single-quotes stay intact; escape ' as '\'' 
+    # Use single-quoted -e payload so SQL single-quotes stay intact; escape ' as '\''
     sql_q = sql.replace("'", "'\\''")
     for bin_name in _mysql_client_bins(db_type, service):
         for auth_pwd in auth_pwds:
@@ -301,7 +497,7 @@ async def sync_mysql_roles_to_password(
             ok, out = await migrator._run_cmd(cmd, timeout=60)
             if ok:
                 migrator.job.log(f"Synced MySQL passwords on {service} ({bin_name})")
-                return
+                return True
             last_out = out or last_out
         cmd2 = (
             f'cd "{cwd}" && docker compose exec -T {service} '
@@ -310,9 +506,27 @@ async def sync_mysql_roles_to_password(
         ok2, out2 = await migrator._run_cmd(cmd2, timeout=60)
         if ok2:
             migrator.job.log(f"Synced MySQL passwords on {service} ({bin_name}, no-password)")
-            return
+            return True
         last_out = out2 or last_out
+
     migrator.job.log(f"MySQL password sync note: {(last_out or '')[-300:]}")
+    if not allow_skip_grant_recovery:
+        return False
+
+    async def _run_list(cmd, cwd=None, timeout=600):
+        return await migrator._run_cmd(cmd, cwd=cwd, timeout=timeout)
+
+    recovered = await recover_mysql_passwords_via_skip_grants(
+        _run_list,
+        service=service,
+        password=new_pwd,
+        app_user=user,
+        db_type=db_type,
+        db_name=schema,
+        compose_cwd=cwd,
+        log=migrator.job.log,
+    )
+    return bool(recovered)
 
 
 async def sync_postgres_roles_to_app_password(

--- a/app/services/pasarguard_ops.py
+++ b/app/services/pasarguard_ops.py
@@ -307,7 +307,21 @@ async def _try_heal_db_auth_mismatch(migrator, logs: str) -> bool:
         migrator.job.log(
             f"Auth failure in panel logs — syncing {target_db} roles for user={app_user}…"
         )
-        admin = await resolve_live_admin_connection(migrator, target_db, env_text=env)
+        try:
+            admin = await resolve_live_admin_connection(migrator, target_db, env_text=env)
+        except RuntimeError as probe_err:
+            if target_db not in ("mysql", "mariadb"):
+                raise
+            # Root password in the volume may differ from every .env candidate —
+            # sync_mysql_roles_to_password will try skip-grant recovery.
+            migrator.job.log(f"Live admin probe failed ({probe_err}) — sync with recovery")
+            admin = {
+                "user": "root",
+                "password": url_pwd,
+                "database": parsed.get("database")
+                or read_env_var(env, "DB_NAME")
+                or "pasarguard",
+            }
         if target_db in ("mysql", "mariadb"):
             await sync_mysql_roles_to_password(
                 migrator,
@@ -316,6 +330,7 @@ async def _try_heal_db_auth_mismatch(migrator, logs: str) -> bool:
                 app_user=app_user,
                 password=url_pwd,
                 env_text=env,
+                db_name=parsed.get("database") or read_env_var(env, "DB_NAME") or "pasarguard",
             )
         else:
             await sync_postgres_roles_to_app_password(

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -1041,38 +1041,68 @@ async def _sync_mysql_passwords(
     password: str,
     user: str = "root",
     db_type: str = "mysql",
-) -> None:
-    """Align MySQL/MariaDB root (and app user) passwords to the value we keep in .env."""
+    db_name: str = "pasarguard",
+    auth_passwords: list[str] | None = None,
+    *,
+    allow_skip_grant_recovery: bool = True,
+) -> bool:
+    """Align MySQL/MariaDB root (and app user) passwords to the value we keep in .env.
+
+    Tries every known root password candidate first (env + extras). Only if root is
+    unreachable does it use temporary ``--skip-grant-tables`` recovery on the same
+    data volume — never wipes MySQL data.
+    """
     if not password or not svc:
-        return
-    # Escape single quotes for SQL
-    lit = (password or "").replace("\\", "\\\\").replace("'", "\\'")
-    statements = [
-        f"ALTER USER 'root'@'%' IDENTIFIED BY '{lit}';",
-        f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{lit}';",
-    ]
+        return False
+
+    from app.services.db_auth import (
+        build_mysql_role_password_sql,
+        mysql_sync_auth_candidates,
+        recover_mysql_passwords_via_skip_grants,
+    )
+
+    env_now = _read_current_env()
     if user and user != "root":
-        statements.append(f"ALTER USER '{user}'@'%' IDENTIFIED BY '{lit}';")
-        statements.append(f"ALTER USER '{user}'@'localhost' IDENTIFIED BY '{lit}';")
-    statements.append("FLUSH PRIVILEGES;")
-    sql = " ".join(statements)
+        app_user = user
+    else:
+        # Still align the panel app role even when caller syncs as root.
+        app_user = (
+            read_env_var(env_now, "DB_USER")
+            or read_env_var(env_now, "MYSQL_USER")
+            or "pasarguard"
+        )
+
+    sql = build_mysql_role_password_sql(
+        password, app_user=app_user, db_name=db_name or "pasarguard",
+    )
+    auth_pwds = mysql_sync_auth_candidates(
+        password,
+        *(auth_passwords or []),
+        env_text=env_now,
+    )
+    job.log(
+        f"Syncing MySQL passwords on {svc} (app user={app_user}, "
+        f"auth candidates={len(auth_pwds)})..."
+    )
     last_out = ""
     for bin_name in _mysql_client_bins(db_type, svc):
-        ok, out = await _run(
-            job,
-            [
-                "docker", "compose", "exec", "-T",
-                svc, bin_name, "-u", "root", f"-p{password}",
-                "-e", sql,
-            ],
-            cwd=str(PASARGUARD_DIR),
-            timeout=60,
-        )
-        if ok:
-            job.log(f"Synced MySQL passwords on {svc} ({bin_name})")
-            return
-        last_out = out or last_out
-        # Retry without assuming current password (fresh container / dump restored old secret)
+        for auth_pwd in auth_pwds:
+            ok, out = await _run(
+                job,
+                [
+                    "docker", "compose", "exec", "-T",
+                    "-e", f"MYSQL_PWD={auth_pwd}",
+                    svc, bin_name, "-u", "root",
+                    "-e", sql,
+                ],
+                cwd=str(PASARGUARD_DIR),
+                timeout=60,
+            )
+            if ok:
+                job.log(f"Synced MySQL passwords on {svc} ({bin_name})")
+                return True
+            last_out = out or last_out
+        # Retry without assuming current password (fresh container / empty root)
         ok2, out2 = await _run(
             job,
             [
@@ -1085,9 +1115,26 @@ async def _sync_mysql_passwords(
         )
         if ok2:
             job.log(f"Synced MySQL passwords on {svc} ({bin_name}, no-password retry)")
-            return
+            return True
         last_out = out2 or last_out
     job.log(f"MySQL password sync note: {(last_out or '')[-300:]}")
+
+    if not allow_skip_grant_recovery:
+        return False
+
+    async def _run_list(cmd, cwd=None, timeout=600):
+        return await _run(job, cmd, cwd=cwd, timeout=timeout)
+
+    return await recover_mysql_passwords_via_skip_grants(
+        _run_list,
+        service=svc,
+        password=password,
+        app_user=app_user,
+        db_type=db_type,
+        db_name=db_name or "pasarguard",
+        compose_cwd=str(PASARGUARD_DIR),
+        log=job.log,
+    )
 
 
 async def _sync_pg_role_passwords(
@@ -1218,7 +1265,10 @@ async def _heal_panel_auth_if_needed(job: MigrationJob, password: str, user: str
         svc = await _detect_db_container(job, db_type)
         if svc and password:
             await _sync_mysql_passwords(
-                job, svc, password, user=user or "root", db_type=db_type,
+                job, svc, password,
+                user=user or "pasarguard",
+                db_type=db_type,
+                db_name=db_name or "pasarguard",
             )
     await _compose(job, "restart", "pasarguard", timeout=120)
     await asyncio.sleep(6)
@@ -2125,8 +2175,15 @@ async def _restore_backup(job: MigrationJob, params: dict, analysis: dict) -> di
                 if svc and sync_pass:
                     await _sync_mysql_passwords(
                         job, svc, sync_pass,
-                        user=bak_user or cur_user or "root",
+                        user=bak_user or cur_user or "pasarguard",
                         db_type=restore_into or installed_db or backup_db,
+                        db_name=bak_name or cur_name or "pasarguard",
+                        auth_passwords=[
+                            p for p in (
+                                bak_mysql_root, bak_db_pass,
+                                cur_mysql_root, cur_db_pass,
+                            ) if p
+                        ],
                     )
         elif backup_db in ("postgresql", "timescaledb"):
             if needs_convert:
@@ -2324,8 +2381,16 @@ async def _restore_backup(job: MigrationJob, params: dict, analysis: dict) -> di
                 )
                 await _sync_mysql_passwords(
                     job, svc, verify_pass,
-                    user=verify_user or "root",
+                    user=verify_user or "pasarguard",
                     db_type=final_engine_pre,
+                    db_name=verify_db or "pasarguard",
+                    auth_passwords=[
+                        p for p in (
+                            cur_mysql_root, cur_db_pass,
+                            bak_mysql_root, bak_db_pass,
+                            live_admin.get("password"),
+                        ) if p
+                    ],
                 )
 
         job.set_progress(88, "Finalizing .env for target database...")

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=2.2.4">
+  <link rel="stylesheet" href="/static/css/style.css?v=2.2.5">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v2.2.4</p>
+          <p class="header-version" id="appVersion">v2.2.5</p>
         </div>
       </div>
       <div class="header-meta">
@@ -579,8 +579,8 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=2.2.4"></script>
-  <script src="/static/js/app.js?v=2.2.4"></script>
+  <script src="/static/js/i18n.js?v=2.2.5"></script>
+  <script src="/static/js/app.js?v=2.2.5"></script>
   <script src="/static/js/wizard-flow.js?v=1.1beta.13"></script>
 </body>
 </html>

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="2.2.4"
+readonly SCRIPT_VERSION="2.2.5"
 readonly INSTALL_DIR="/opt/pg-migrator"
 readonly SERVICE_NAME="pg-migrator"
 readonly WEB_PORT=7000

--- a/tests/test_db_auth.py
+++ b/tests/test_db_auth.py
@@ -170,7 +170,7 @@ def test_sync_mysql_roles_runs_alter_user_shell():
         with patch("app.services.db_auth.resolve_db_service", return_value="mysql"), \
              patch("app.services.db_auth.PASARGUARD_DIR", Path("/opt/pasarguard")), \
              patch.object(Dummy, "_run_cmd", fake_run):
-            await sync_mysql_roles_to_password(
+            ok = await sync_mysql_roles_to_password(
                 migrator,
                 "mysql",
                 {"user": "root", "password": "rootpw"},
@@ -178,11 +178,207 @@ def test_sync_mysql_roles_runs_alter_user_shell():
                 password="rootpw",
                 env_text="DB_USER=pasarguard\nMYSQL_ROOT_PASSWORD=rootpw\n",
             )
+        assert ok is True
         assert seen
         assert any("ALTER USER" in s and "pasarguard" in s for s in seen)
+        assert any("127.0.0.1" in s for s in seen)
+        assert not any("skip-grant-tables" in s for s in seen)
 
     asyncio.run(_run())
     print("OK: sync_mysql_roles ALTER USER")
+
+
+def test_build_mysql_role_password_sql_hosts_and_grants():
+    from app.services.db_auth import build_mysql_role_password_sql
+
+    sql = build_mysql_role_password_sql("s3cret", app_user="pasarguard", db_name="pasarguard")
+    assert "CREATE USER IF NOT EXISTS 'pasarguard'@'127.0.0.1'" in sql
+    assert "ALTER USER 'pasarguard'@'127.0.0.1' IDENTIFIED BY 's3cret'" in sql
+    assert "ALTER USER 'root'@'%'" in sql
+    assert "GRANT ALL PRIVILEGES ON `pasarguard`.* TO 'pasarguard'@'%'" in sql
+    assert "FLUSH PRIVILEGES;" in sql
+    skip = build_mysql_role_password_sql(
+        "x", app_user="u", include_flush_first=True,
+    )
+    assert skip.startswith("FLUSH PRIVILEGES;")
+    print("OK: build_mysql_role_password_sql hosts/grants")
+
+
+def test_mysql_sync_auth_candidates_merges_env_and_extras():
+    from app.services.db_auth import mysql_sync_auth_candidates
+
+    env = "MYSQL_ROOT_PASSWORD=rootpw\nDB_PASSWORD=apppw\n"
+    c = mysql_sync_auth_candidates("extra", "rootpw", env_text=env)
+    assert c[0] == "extra"
+    assert "rootpw" in c
+    assert "apppw" in c
+    print("OK: mysql_sync_auth_candidates merge")
+
+
+def test_sync_mysql_roles_tries_old_password_then_succeeds():
+    """Install root password still works even when .env target password differs."""
+    import asyncio
+    from unittest.mock import patch
+
+    from app.services.db_auth import sync_mysql_roles_to_password
+    from app.services.migrators.base import BaseMigrator, MigrationJob
+
+    class Dummy(BaseMigrator):
+        async def run(self, params):
+            return {}
+
+    async def _run():
+        job = MigrationJob(job_id="sync2")
+        migrator = Dummy(job, {})
+        seen = []
+
+        async def fake_run(self, cmd, cwd=None, timeout=600):
+            text = cmd if isinstance(cmd, str) else " ".join(cmd)
+            seen.append(text)
+            # Fail until we authenticate with the old/install password.
+            if '-p"oldroot"' in text or "-poldroot" in text:
+                return True, "ok"
+            if "skip-grant-tables" in text:
+                raise AssertionError("skip-grant must not run when a candidate works")
+            return False, "Access denied"
+
+        with patch("app.services.db_auth.resolve_db_service", return_value="mysql"), \
+             patch("app.services.db_auth.PASARGUARD_DIR", Path("/opt/pasarguard")), \
+             patch.object(Dummy, "_run_cmd", fake_run):
+            ok = await sync_mysql_roles_to_password(
+                migrator,
+                "mysql",
+                {"user": "root", "password": "oldroot"},
+                app_user="pasarguard",
+                password="newroot",
+                env_text="DB_USER=pasarguard\nMYSQL_ROOT_PASSWORD=newroot\nDB_PASSWORD=newroot\n",
+            )
+        assert ok is True
+        assert any("oldroot" in s for s in seen)
+        assert not any("skip-grant-tables" in s for s in seen)
+
+    asyncio.run(_run())
+    print("OK: sync tries install password before skip-grant")
+
+
+def test_sync_mysql_roles_skip_grant_recovery_when_locked_out():
+    import asyncio
+    from unittest.mock import patch
+
+    from app.services.db_auth import sync_mysql_roles_to_password
+    from app.services.migrators.base import BaseMigrator, MigrationJob
+
+    class Dummy(BaseMigrator):
+        async def run(self, params):
+            return {}
+
+    async def _run():
+        job = MigrationJob(job_id="sync3")
+        migrator = Dummy(job, {})
+        seen = []
+        heal_ready = {"n": 0}
+
+        async def immediate_sleep(*_a, **_k):
+            return None
+
+        async def fake_run(self, cmd, cwd=None, timeout=600):
+            if isinstance(cmd, list):
+                text = " ".join(cmd)
+            else:
+                text = cmd
+            seen.append(text)
+
+            # Post-recovery verify on the normal service.
+            if "compose exec" in text and "MYSQL_PWD=newroot" in text and "SELECT 1" in text:
+                return True, "1\n"
+
+            # Normal exec attempts fail (locked out) — shell strings from sync.
+            if "compose exec" in text and "skip-grant" not in text:
+                return False, (
+                    "ERROR 1045 (28000): Access denied for user 'root'@'localhost'"
+                )
+
+            if isinstance(cmd, list) and len(cmd) >= 3 and cmd[0] == "docker" and cmd[1] == "rm":
+                return True, ""
+            if isinstance(cmd, list) and cmd[:3] == ["docker", "compose", "stop"]:
+                return True, ""
+            if isinstance(cmd, list) and "run" in cmd and "--skip-grant-tables" in cmd:
+                return True, "healcid"
+            if isinstance(cmd, list) and cmd[:2] == ["docker", "exec"] and "SELECT 1" in text:
+                heal_ready["n"] += 1
+                return True, "1\n"
+            if isinstance(cmd, list) and cmd[:2] == ["docker", "exec"] and "ALTER USER" in text:
+                assert "FLUSH PRIVILEGES;" in text
+                assert "127.0.0.1" in text
+                return True, "ok"
+            if isinstance(cmd, list) and cmd[:2] == ["docker", "stop"]:
+                return True, ""
+            if isinstance(cmd, list) and cmd[:3] == ["docker", "compose", "up"]:
+                return True, ""
+            return False, "no"
+
+        with patch("app.services.db_auth.resolve_db_service", return_value="mysql"), \
+             patch("app.services.db_auth.PASARGUARD_DIR", Path("/opt/pasarguard")), \
+             patch("asyncio.sleep", immediate_sleep), \
+             patch.object(Dummy, "_run_cmd", fake_run):
+            ok = await sync_mysql_roles_to_password(
+                migrator,
+                "mysql",
+                {"user": "root", "password": "wrong"},
+                app_user="pasarguard",
+                password="newroot",
+                env_text="DB_USER=pasarguard\nMYSQL_ROOT_PASSWORD=newroot\n",
+            )
+        assert ok is True
+        assert any("skip-grant-tables" in s for s in seen)
+        assert any("compose stop" in s for s in seen)
+        assert any("compose up" in s and "-d" in s and "mysql" in s for s in seen)
+        assert heal_ready["n"] >= 1
+
+    asyncio.run(_run())
+    print("OK: skip-grant recovery when root locked out")
+
+
+def test_pg_restore_sync_mysql_uses_candidates_then_recovery():
+    import asyncio
+    from unittest.mock import patch
+
+    from app.services.migrators.base import MigrationJob
+    from app.services import pg_restore
+
+    async def _run():
+        job = MigrationJob(job_id="rsync1")
+        calls = []
+
+        async def fake_run(job_arg, cmd, cwd=None, timeout=600):
+            text = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            calls.append(text)
+            if "compose exec" in text and "MYSQL_PWD=oldinstall" in text and "ALTER USER" in text:
+                return True, "ok"
+            if "compose exec" in text:
+                return False, "Access denied"
+            return True, "ok"
+
+        with patch.object(pg_restore, "_run", fake_run), \
+             patch.object(pg_restore, "_read_current_env", return_value=(
+                 "DB_USER=pasarguard\nMYSQL_ROOT_PASSWORD=newbak\nDB_PASSWORD=newbak\n"
+             )), \
+             patch.object(pg_restore, "PASARGUARD_DIR", Path("/opt/pasarguard")):
+            ok = await pg_restore._sync_mysql_passwords(
+                job,
+                "mysql",
+                "newbak",
+                user="pasarguard",
+                db_type="mysql",
+                db_name="pasarguard",
+                auth_passwords=["oldinstall"],
+            )
+        assert ok is True
+        assert any("MYSQL_PWD=oldinstall" in c for c in calls)
+        assert not any("skip-grant-tables" in c for c in calls)
+
+    asyncio.run(_run())
+    print("OK: pg_restore sync uses auth_passwords before recovery")
 
 
 def test_mysql_probe_shell_string_via_base_migrator():
@@ -257,6 +453,11 @@ if __name__ == "__main__":
     test_mysql_password_candidates()
     test_mysql_password_candidates_from_sqlalchemy_url()
     test_explain_auth_mariadb_target_from_timescale()
+    test_build_mysql_role_password_sql_hosts_and_grants()
+    test_mysql_sync_auth_candidates_merges_env_and_extras()
     test_sync_mysql_roles_runs_alter_user_shell()
+    test_sync_mysql_roles_tries_old_password_then_succeeds()
+    test_sync_mysql_roles_skip_grant_recovery_when_locked_out()
+    test_pg_restore_sync_mysql_uses_candidates_then_recovery()
     test_mysql_probe_shell_string_via_base_migrator()
     print("\nAll db_auth tests passed")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Restore/heal could fail with `Access denied for user 'pasarguard'@'127.0.0.1'` and then fail to auto-heal because `_sync_mysql_passwords` only tried the single `.env` password (and empty root). If the MySQL data volume still had a different root password, heal could not `ALTER USER`, so migrations and `COUNT(users)` verification failed hard.

## Fix
- Try **all known MySQL password candidates** (`.env` + backup/install extras) before giving up
- Align roles for `%`, `localhost`, and `127.0.0.1` (panel often uses TCP to 127.0.0.1), with `CREATE USER IF NOT EXISTS` + grants
- **Last resort only**: temporary `--skip-grant-tables --skip-networking` recovery on the **same data volume** (no wipe), then restart the normal MySQL/MariaDB service
- Same recovery path for restore heal and panel auth-mismatch heal
- Happy paths unchanged: if any known password works, skip-grant is never used

## Tests
- Unit coverage for SQL hosts/grants, candidate merge, old-password success without recovery, and skip-grant recovery when locked out
- Existing `test_db_auth` / `test_pg_restore` suites pass

Version bump: **v2.2.5**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fddf1-feb8-756d-b9db-e686139c545f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fddf1-feb8-756d-b9db-e686139c545f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

