### PR TITLE
Fix MySQL root@127.0.0.1 privileges + soft settings verify (v2.2.6)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.5`** — Always take a full backup before restore or migration.
+> ⚠️ **`v2.2.6`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -56,6 +56,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v2.2.6 | Fix MySQL root@127.0.0.1 created without privileges (alembic 1044) + soft settings row-count verify |
 | v2.2.5 | Fix MySQL restore heal when root password in the volume no longer matches .env (try all candidates, then safe skip-grant recovery on the same volume) |
 | v2.2.4 | Fix Marzban cross-DB migrate NameError: missing PASARGUARD_ENV import in panel-boot |
 | v2.2.3 | Fix modern 3x-ui migrate crash on empty uuid + integer clients.id |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v2.2.5`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v2.2.6`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -58,6 +58,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v2.2.6 | فیکس ساخت root@127.0.0.1 بدون privilege (alembic 1044) + soft کردن verify تعداد settings |
 | v2.2.5 | فیکس heal ریستور MySQL وقتی رمز root داخل volume با .env یکی نیست (امتحان همهٔ کاندیداها، بعد recovery امن skip-grant روی همان volume) |
 | v2.2.4 | فیکس NameError مهاجرت Marzban cross-DB: import جاافتاده PASARGUARD_ENV در panel-boot |
 | v2.2.3 | فیکس کرش مهاجرت 3x-ui مدرن: uuid خالی + clients.id عددی |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.5`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v2.2.6`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -56,6 +56,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v2.2.6 | Исправление root@127.0.0.1 без привилегий (alembic 1044) + soft-проверка counts settings |
 | v2.2.5 | Исправление heal restore MySQL, когда пароль root в volume не совпадает с .env (все кандидаты, затем безопасный skip-grant recovery на том же volume) |
 | v2.2.4 | Исправление NameError миграции Marzban cross-DB: отсутствовал import PASARGUARD_ENV в panel-boot |
 | v2.2.3 | Исправление краша миграции modern 3x-ui: пустой uuid + числовой clients.id |

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "2.2.5"
+APP_VERSION = "2.2.6"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/services/db_auth.py
+++ b/app/services/db_auth.py
@@ -257,8 +257,10 @@ def build_mysql_role_password_sql(
 ) -> str:
     """SQL to align root + app user passwords for %, localhost, and 127.0.0.1.
 
-    Panel traffic often uses TCP to 127.0.0.1 (distinct from localhost socket).
-    CREATE USER IF NOT EXISTS keeps the statement safe when a host row is missing.
+    Panel / alembic traffic often uses TCP to 127.0.0.1 (distinct from localhost
+    socket). CREATE USER IF NOT EXISTS is safe when a host row is missing, but a
+    newly created ``root@127.0.0.1`` is *not* a superuser — we must GRANT *.*
+    WITH GRANT OPTION or alembic fails with error 1044 (Access denied to database).
     """
     lit = _mysql_sql_literal(password)
     hosts = ("%", "localhost", "127.0.0.1")
@@ -269,6 +271,10 @@ def build_mysql_role_password_sql(
     for host in hosts:
         statements.append(f"CREATE USER IF NOT EXISTS 'root'@'{host}' IDENTIFIED BY '{lit}';")
         statements.append(f"ALTER USER 'root'@'{host}' IDENTIFIED BY '{lit}';")
+        # Critical: new root@host rows start with zero privileges.
+        statements.append(
+            f"GRANT ALL PRIVILEGES ON *.* TO 'root'@'{host}' WITH GRANT OPTION;"
+        )
     user = (app_user or "").strip()
     if user and user != "root":
         for host in hosts:

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -1916,14 +1916,29 @@ async def _verify_restored_data(
         raise RuntimeError(f"Unsupported final_db for verification: {final_db}")
 
     gaps = []
+    soft_gaps = []
+    # settings row counts often drift across PasarGuard versions (many KV rows →
+    # one JSON blob) and mysqldump INSERT estimators over-count parentheses in
+    # JSON values. Do not fail restore on settings alone when data is present.
+    soft_tables = frozenset({"settings"})
     for table, want in expected.items():
         got = actual.get(table, -1)
         if got < 0:
             gaps.append(f"{table}: unreadable/{want}")
         elif got < want:
-            gaps.append(f"{table}: {got}/{want}")
+            msg = f"{table}: {got}/{want}"
+            if table in soft_tables and got > 0:
+                soft_gaps.append(msg)
+                job.log(f"Verified {table}: {got} rows (expected ≥{want}, soft OK)")
+            else:
+                gaps.append(msg)
         else:
             job.log(f"Verified {table}: {got} rows (expected ≥{want})")
+
+    if soft_gaps:
+        job.log(
+            "Soft verify note (non-fatal): " + "; ".join(soft_gaps)
+        )
 
     # Even without precise dump estimates: refuse empty critical panel after restore
     critical = [t for t in STRICT_COMPLETE_TABLES if t in ("users", "hosts", "groups", "nodes", "admins", "inbounds")]

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=2.2.5">
+  <link rel="stylesheet" href="/static/css/style.css?v=2.2.6">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v2.2.5</p>
+          <p class="header-version" id="appVersion">v2.2.6</p>
         </div>
       </div>
       <div class="header-meta">
@@ -579,8 +579,8 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=2.2.5"></script>
-  <script src="/static/js/app.js?v=2.2.5"></script>
+  <script src="/static/js/i18n.js?v=2.2.6"></script>
+  <script src="/static/js/app.js?v=2.2.6"></script>
   <script src="/static/js/wizard-flow.js?v=1.1beta.13"></script>
 </body>
 </html>

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="2.2.5"
+readonly SCRIPT_VERSION="2.2.6"
 readonly INSTALL_DIR="/opt/pg-migrator"
 readonly SERVICE_NAME="pg-migrator"
 readonly WEB_PORT=7000

--- a/tests/test_db_auth.py
+++ b/tests/test_db_auth.py
@@ -195,6 +195,8 @@ def test_build_mysql_role_password_sql_hosts_and_grants():
     assert "CREATE USER IF NOT EXISTS 'pasarguard'@'127.0.0.1'" in sql
     assert "ALTER USER 'pasarguard'@'127.0.0.1' IDENTIFIED BY 's3cret'" in sql
     assert "ALTER USER 'root'@'%'" in sql
+    assert "GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION" in sql
+    assert "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%'" in sql
     assert "GRANT ALL PRIVILEGES ON `pasarguard`.* TO 'pasarguard'@'%'" in sql
     assert "FLUSH PRIVILEGES;" in sql
     skip = build_mysql_role_password_sql(

--- a/tests/test_pg_restore.py
+++ b/tests/test_pg_restore.py
@@ -332,6 +332,97 @@ def test_filter_globals_sql_makes_create_role_idempotent():
     assert "ALTER ROLE pasarguard WITH NOSUPERUSER NOCREATEDB LOGIN;" in result
 
 
+def test_verify_settings_soft_when_critical_ok():
+    """settings 1/16 must not fail restore when users/hosts/… match (dump estimator noise)."""
+    import asyncio
+    from unittest.mock import patch
+
+    from app.services.migrators.base import MigrationJob
+    from app.services import pg_restore
+
+    counts = {
+        "users": "69",
+        "hosts": "15",
+        "groups": "2",
+        "nodes": "2",
+        "inbounds": "3",
+        "admins": "2",
+        "settings": "1",
+        "users_groups_association": "70",
+        "inbounds_groups_association": "3",
+        "core_configs": "2",
+    }
+    expected = {k: int(v) if k != "settings" else 16 for k, v in counts.items()}
+    # expected settings=16, actual=1 via counts
+
+    async def fake_run(job, cmd, cwd=None, timeout=600):
+        text = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+        for table, n in counts.items():
+            if f"FROM `{table}`" in text or f'FROM "{table}"' in text:
+                return True, f"{n}\n"
+        return False, "no"
+
+    async def _run():
+        job = MigrationJob(job_id="verify1")
+        with patch.object(pg_restore, "_run", fake_run), \
+             patch.object(pg_restore, "_detect_db_container", return_value="mysql"), \
+             patch.object(pg_restore, "PASARGUARD_DIR", Path("/opt/pasarguard")):
+            actual = await pg_restore._verify_restored_data(
+                job,
+                "mysql",
+                "secret",
+                "pasarguard",
+                "pasarguard",
+                expected,
+                require_any_data=True,
+            )
+        assert actual["users"] == 69
+        assert actual["settings"] == 1
+        assert any("soft" in (ln or "").lower() or "settings" in (ln or "").lower()
+                   for ln in job.logs)
+
+    asyncio.run(_run())
+    print("OK: settings soft verify when critical tables match")
+
+
+def test_verify_users_gap_still_hard_fails():
+    import asyncio
+    from unittest.mock import patch
+
+    from app.services.migrators.base import MigrationJob
+    from app.services import pg_restore
+
+    async def fake_run(job, cmd, cwd=None, timeout=600):
+        text = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+        if "FROM `users`" in text:
+            return True, "10\n"
+        if "FROM `hosts`" in text:
+            return True, "15\n"
+        return True, "0\n"
+
+    async def _run():
+        job = MigrationJob(job_id="verify2")
+        with patch.object(pg_restore, "_run", fake_run), \
+             patch.object(pg_restore, "_detect_db_container", return_value="mysql"), \
+             patch.object(pg_restore, "PASARGUARD_DIR", Path("/opt/pasarguard")):
+            try:
+                await pg_restore._verify_restored_data(
+                    job,
+                    "mysql",
+                    "secret",
+                    "pasarguard",
+                    "pasarguard",
+                    {"users": 69, "hosts": 15},
+                    require_any_data=True,
+                )
+                raise AssertionError("expected RuntimeError for users gap")
+            except RuntimeError as e:
+                assert "users: 10/69" in str(e)
+
+    asyncio.run(_run())
+    print("OK: users gap still hard-fails")
+
+
 if __name__ == "__main__":
     test_soft_db_family_matrix()
     test_filter_timescaledb_extension_sql()
@@ -351,4 +442,6 @@ if __name__ == "__main__":
     test_analyze_all_db_types()
     test_analyze_experimental_hard_mismatch()
     test_filter_globals_sql_makes_create_role_idempotent()
+    test_verify_settings_soft_when_critical_ok()
+    test_verify_users_gap_still_hard_fails()
     print("\nAll pg_restore tests passed")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (seen after v2.2.5)

Password heal worked (users=69 verified), but:

1. **Alembic 1044:** `Access denied for user 'root'@'127.0.0.1' to database 'pasarguard'`  
   Password sync created `root@127.0.0.1` without privileges. MySQL prefers that host over `root@%` for TCP, so alembic authenticated but had no DB access.

2. **False verify fail:** `settings: 1/16` while all critical tables matched. Dump INSERT estimators over-count JSON parentheses; settings schema also drifts across versions.

## Fix
- After CREATE/ALTER root for `%` / `localhost` / `127.0.0.1`, `GRANT ALL PRIVILEGES ON *.* … WITH GRANT OPTION`
- Soft-verify `settings` when `got > 0` (warn only); users/hosts/groups/nodes/inbounds/admins still hard-fail

Version: **v2.2.6**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fddf1-feb8-756d-b9db-e686139c545f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fddf1-feb8-756d-b9db-e686139c545f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

