### PR TITLE
Fix Marzban large MySQL dump hang (v2.2.7)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.6`** — Always take a full backup before restore or migration.
+> ⚠️ **`v2.2.7`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -56,6 +56,7 @@ Requirements: Ubuntu/Debian · root · Docker
 
 | Version | Key changes |
 |---------|-------------|
+| v2.2.7 | Fix Marzban migrate hang on large MySQL dumps (stream rewrite + ready wait + progress heartbeats) |
 | v2.2.6 | Fix MySQL root@127.0.0.1 created without privileges (alembic 1044) + soft settings row-count verify |
 | v2.2.5 | Fix MySQL restore heal when root password in the volume no longer matches .env (try all candidates, then safe skip-grant recovery on the same volume) |
 | v2.2.4 | Fix Marzban cross-DB migrate NameError: missing PASARGUARD_ENV import in panel-boot |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v2.2.6`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v2.2.7`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -58,6 +58,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | نسخه | تغییرات اصلی |
 |------|--------------|
+| v2.2.7 | فیکس هنگ مهاجرت Marzban روی دامپ بزرگ MySQL (استریم ری‌رایت + انتظار آماده بودن + heartbeat پیشرفت) |
 | v2.2.6 | فیکس ساخت root@127.0.0.1 بدون privilege (alembic 1044) + soft کردن verify تعداد settings |
 | v2.2.5 | فیکس heal ریستور MySQL وقتی رمز root داخل volume با .env یکی نیست (امتحان همهٔ کاندیداها، بعد recovery امن skip-grant روی همان volume) |
 | v2.2.4 | فیکس NameError مهاجرت Marzban cross-DB: import جاافتاده PASARGUARD_ENV در panel-boot |

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v2.2.6`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v2.2.7`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -56,6 +56,7 @@ sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG
 
 | Версия | Основные изменения |
 |--------|-------------------|
+| v2.2.7 | Исправление зависания миграции Marzban на больших MySQL dump (stream rewrite + ready wait + heartbeat прогресса) |
 | v2.2.6 | Исправление root@127.0.0.1 без привилегий (alembic 1044) + soft-проверка counts settings |
 | v2.2.5 | Исправление heal restore MySQL, когда пароль root в volume не совпадает с .env (все кандидаты, затем безопасный skip-grant recovery на том же volume) |
 | v2.2.4 | Исправление NameError миграции Marzban cross-DB: отсутствовал import PASARGUARD_ENV в panel-boot |

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "2.2.6"
+APP_VERSION = "2.2.7"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/services/env_migration.py
+++ b/app/services/env_migration.py
@@ -1099,11 +1099,54 @@ def transform_xray_config(text: str) -> str:
     return text.replace("/var/lib/marzban", "/var/lib/pasarguard").replace("/opt/marzban", "/opt/pasarguard")
 
 
+def fix_mysql_dump_line_for_pasarguard(line: str) -> str:
+    """Rewrite one dump line: CREATE/USE db name, then safe marzban→pasarguard."""
+    line = re.sub(r"(?i)^(CREATE DATABASE.*)\bmarzban\b", r"\1pasarguard", line)
+    line = re.sub(r"(?i)^(USE )\bmarzban\b", r"\1pasarguard", line)
+    return line.replace("marzban", "pasarguard")
+
+
 def fix_mysql_dump_for_pasarguard(sql_text: str) -> str:
-    """Official sed: CREATE DATABASE and USE lines only, then safe rename."""
-    sql_text = re.sub(r"(?m)^(CREATE DATABASE.*)\bmarzban\b", r"\1pasarguard", sql_text, flags=re.I)
-    sql_text = re.sub(r"(?m)^(USE )\bmarzban\b", r"\1pasarguard", sql_text, flags=re.I)
-    return sql_text.replace("marzban", "pasarguard")
+    """Rewrite Marzban MySQL dump text for PasarGuard (line-oriented)."""
+    if not sql_text:
+        return sql_text
+    return "".join(
+        fix_mysql_dump_line_for_pasarguard(line)
+        for line in sql_text.splitlines(keepends=True)
+    )
+
+
+def rewrite_mysql_dump_file_for_pasarguard(src: Path, dest: Path) -> int:
+    """Stream-rewrite a dump file without loading the whole SQL into memory.
+
+    Returns the number of lines that changed. Safe for multi-hundred-MB dumps.
+    """
+    src = Path(src)
+    dest = Path(dest)
+    if not src.exists():
+        raise RuntimeError(f"MySQL dump not found: {src}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    changed = 0
+    # Write via temp when dest == src so a crash cannot truncate the dump.
+    tmp = dest if dest.resolve() != src.resolve() else dest.with_suffix(dest.suffix + ".rewriting")
+    try:
+        with src.open("r", encoding="utf-8", errors="ignore") as fin, tmp.open(
+            "w", encoding="utf-8", newline=""
+        ) as fout:
+            for line in fin:
+                new_line = fix_mysql_dump_line_for_pasarguard(line)
+                if new_line != line:
+                    changed += 1
+                fout.write(new_line)
+        if tmp != dest:
+            tmp.replace(dest)
+    finally:
+        if tmp != dest and tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+    return changed
 
 
 MIGRATE_ENV_KEYS = {

--- a/app/services/migrators/marzban.py
+++ b/app/services/migrators/marzban.py
@@ -4,6 +4,7 @@ import asyncio
 import re
 import shutil
 import sqlite3
+import time
 from pathlib import Path
 
 from app.config import (
@@ -16,7 +17,7 @@ from app.services.env_migration import (
     transform_marzban_env,
     transform_compose_marzban_to_pasarguard,
     transform_xray_config,
-    fix_mysql_dump_for_pasarguard,
+    rewrite_mysql_dump_file_for_pasarguard,
     read_env_var,
     merge_marzban_env_into_pasarguard,
     get_panel_url_from_env,
@@ -617,9 +618,62 @@ class MarzbanMigrator(BaseMigrator):
             await proc.wait()
         if not dump_path.exists():
             raise RuntimeError("Failed to dump Marzban MySQL — check password and docker")
-        text = fix_mysql_dump_for_pasarguard(dump_path.read_text(encoding="utf-8", errors="ignore"))
-        dump_path.write_text(text, encoding="utf-8")
+        changed = rewrite_mysql_dump_file_for_pasarguard(dump_path, dump_path)
+        size_mb = dump_path.stat().st_size / (1024 * 1024)
+        self.job.log(
+            f"Prepared Marzban MySQL dump ({size_mb:.1f} MB, {changed} lines rewritten)"
+        )
         return dump_path
+
+    async def _wait_compose_mysql_ready(
+        self,
+        svc: str,
+        user: str,
+        pwd: str,
+        host: str,
+        *,
+        attempts: int = 90,
+    ) -> None:
+        """Wait until compose MySQL/MariaDB accepts queries (not just container start)."""
+        self.job.log(f"Waiting for {svc} to accept connections...")
+        last = ""
+        clients = ("mysql", "mariadb")
+        admins = ("mysqladmin", "mariadb-admin")
+        for attempt in range(max(1, attempts)):
+            ping_ok = False
+            for admin in admins:
+                proc = await asyncio.create_subprocess_exec(
+                    "docker", "compose", "exec", "-T", svc,
+                    admin, "ping", "-h", host, f"-u{user}", f"-p{pwd}", "--silent",
+                    cwd=str(PASARGUARD_DIR),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                )
+                out_b, _ = await proc.communicate()
+                last = (out_b or b"").decode("utf-8", errors="replace")
+                if proc.returncode == 0:
+                    ping_ok = True
+                    break
+            if ping_ok:
+                for client in clients:
+                    proc = await asyncio.create_subprocess_exec(
+                        "docker", "compose", "exec", "-T", svc,
+                        client, "-u", user, f"-p{pwd}", "-h", host, "-e", "SELECT 1;",
+                        cwd=str(PASARGUARD_DIR),
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.STDOUT,
+                    )
+                    out_b, _ = await proc.communicate()
+                    last = (out_b or b"").decode("utf-8", errors="replace")
+                    if proc.returncode == 0:
+                        self.job.log(f"{svc} is ready")
+                        return
+            if attempt == 0 or (attempt + 1) % 5 == 0:
+                self.job.log(f"Still waiting for {svc}... ({attempt + 1}/{attempts})")
+            await asyncio.sleep(2)
+        raise RuntimeError(
+            f"{svc} did not become ready in time. Last output:\n{(last or '')[-400:]}"
+        )
 
     async def _import_mysql_dump(self, dump_file: Path):
         conn = get_target_connection(self.params)
@@ -627,12 +681,20 @@ class MarzbanMigrator(BaseMigrator):
         pwd = conn.get("password") or ""
         db = conn.get("database") or "pasarguard"
         host = conn.get("host") or "127.0.0.1"
+        dump_file = Path(dump_file)
+        if not dump_file.exists():
+            raise RuntimeError(f"Marzban MySQL dump not found: {dump_file}")
+
+        size_mb = dump_file.stat().st_size / (1024 * 1024)
         fixed = dump_file.parent / "fixed_import.sql"
-        text = fix_mysql_dump_for_pasarguard(dump_file.read_text(encoding="utf-8", errors="ignore"))
-        fixed.write_text(text, encoding="utf-8")
+        self.job.log(f"Rewriting MySQL dump for PasarGuard ({size_mb:.1f} MB, streaming)...")
+        changed = rewrite_mysql_dump_file_for_pasarguard(dump_file, fixed)
+        self.job.log(f"Dump rewrite complete ({changed} lines changed)")
+
         svc = resolve_db_service("mysql") or resolve_db_service("mariadb") or "mysql"
         await self._run_cmd(["docker", "compose", "up", "-d", svc], cwd=str(PASARGUARD_DIR))
-        await asyncio.sleep(6)
+        await self._wait_compose_mysql_ready(svc, user, pwd, host)
+
         from app.services.native_migration.sql_staging import (
             mysql_create_db_sql,
             mysql_shell_e_arg,
@@ -640,21 +702,89 @@ class MarzbanMigrator(BaseMigrator):
 
         # Single-quote -e SQL: double quotes expand backticks via command substitution
         e_sql = mysql_shell_e_arg(mysql_create_db_sql(db, drop_first=True))
+        self.job.log(f"Recreating target database `{db}`...")
         wipe = await asyncio.create_subprocess_shell(
             f'cd "{PASARGUARD_DIR}" && docker compose exec -T {svc} '
-            f'mysql -u {user} -p"{pwd}" -h {host} -e {e_sql}'
+            f'mysql -u {user} -p"{pwd}" -h {host} -e {e_sql}',
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
         )
-        await wipe.wait()
-        proc = await asyncio.create_subprocess_shell(
-            f'cd "{PASARGUARD_DIR}" && docker compose exec -T {svc} '
-            f'mysql -u {user} -p"{pwd}" -h {host} {db} < "{fixed}"',
+        wipe_out_b, _ = await wipe.communicate()
+        if wipe.returncode != 0:
+            wipe_out = (wipe_out_b or b"").decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Failed to recreate target database `{db}` "
+                f"(exit {wipe.returncode}): {wipe_out[-400:]}"
+            )
+
+        self.job.set_progress(
+            45,
+            f"Importing Marzban dump into PasarGuard mysql ({size_mb:.0f} MB)...",
         )
-        await proc.wait()
+        self.job.log(
+            f"Importing MySQL dump into `{db}` via docker compose exec stdin "
+            f"({size_mb:.1f} MB — large dumps can take a long time)..."
+        )
+
+        # Prefer exec+stdin over shell redirect so host paths outside mounts work
+        # and passwords/special chars are not re-parsed by a shell.
+        with fixed.open("rb") as fh:
+            proc = await asyncio.create_subprocess_exec(
+                "docker", "compose", "exec", "-T", svc,
+                "mysql", "-u", user, f"-p{pwd}", "-h", host, db,
+                cwd=str(PASARGUARD_DIR),
+                stdin=fh,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+
+            output_lines: list[str] = []
+
+            async def _drain_stdout() -> None:
+                assert proc.stdout is not None
+                while True:
+                    line = await proc.stdout.readline()
+                    if not line:
+                        break
+                    text = line.decode("utf-8", errors="replace").rstrip()
+                    if text:
+                        output_lines.append(text)
+
+            drain_task = asyncio.create_task(_drain_stdout())
+            started = time.monotonic()
+            # No short timeout: 400MB+ imports are legitimate and must finish.
+            while True:
+                try:
+                    await asyncio.wait_for(asyncio.shield(drain_task), timeout=20)
+                    break
+                except (TimeoutError, asyncio.TimeoutError):
+                    elapsed = int(time.monotonic() - started)
+                    # Keep UI moving between 45% and 65% while import runs.
+                    pct = min(65, 45 + (elapsed // 30))
+                    self.job.set_progress(
+                        pct,
+                        f"Importing Marzban dump into PasarGuard mysql "
+                        f"({size_mb:.0f} MB, {elapsed}s)...",
+                    )
+                    self.job.log(f"Still importing MySQL dump... ({elapsed}s elapsed)")
+            await proc.wait()
+            if not drain_task.done():
+                await drain_task
+            elapsed = int(time.monotonic() - started)
+
         if proc.returncode != 0:
+            tail = "\n".join(output_lines[-40:])
             raise RuntimeError(
                 f"Failed to import Marzban MySQL dump into PasarGuard "
                 f"(exit {proc.returncode}). Check DB credentials and container logs."
+                + (f"\n{tail}" if tail else "")
             )
+        self.job.log(f"MySQL dump import finished ({elapsed}s)")
+        try:
+            if fixed.exists() and fixed.resolve() != dump_file.resolve():
+                fixed.unlink()
+        except OSError:
+            pass
 
     async def _update_env_paths(self, source_db: str, target_db: str):
         env_path = PASARGUARD_DIR / ".env"

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=2.2.6">
+  <link rel="stylesheet" href="/static/css/style.css?v=2.2.7">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v2.2.6</p>
+          <p class="header-version" id="appVersion">v2.2.7</p>
         </div>
       </div>
       <div class="header-meta">
@@ -579,8 +579,8 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=2.2.6"></script>
-  <script src="/static/js/app.js?v=2.2.6"></script>
+  <script src="/static/js/i18n.js?v=2.2.7"></script>
+  <script src="/static/js/app.js?v=2.2.7"></script>
   <script src="/static/js/wizard-flow.js?v=1.1beta.13"></script>
 </body>
 </html>

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="2.2.6"
+readonly SCRIPT_VERSION="2.2.7"
 readonly INSTALL_DIR="/opt/pg-migrator"
 readonly SERVICE_NAME="pg-migrator"
 readonly WEB_PORT=7000

--- a/tests/test_env_migration.py
+++ b/tests/test_env_migration.py
@@ -10,6 +10,7 @@ from app.services.env_migration import (
     transform_marzban_env,
     transform_compose_marzban_to_pasarguard,
     fix_mysql_dump_for_pasarguard,
+    rewrite_mysql_dump_file_for_pasarguard,
     read_env_var,
     extract_env_password_candidates,
     pick_primary_env_password,
@@ -55,8 +56,36 @@ def test_compose_transform():
 def test_mysql_dump_fix():
     sql = "CREATE DATABASE marzban;\nUSE marzban;\nINSERT INTO users VALUES (1);"
     out = fix_mysql_dump_for_pasarguard(sql)
-    assert "CREATE DATABASE pasarguard" in out or "pasarguard" in out
+    assert "CREATE DATABASE pasarguard" in out
+    assert "USE pasarguard" in out
+    assert "marzban" not in out.lower()
     print("OK: mysql dump fix")
+
+
+def test_mysql_dump_file_rewrite_streams(tmp_path=None):
+    """File rewrite must match in-memory fix and support in-place rewrite."""
+    import tempfile
+
+    sql = (
+        "CREATE DATABASE /*!32312 IF NOT EXISTS*/ `marzban`;\n"
+        "USE `marzban`;\n"
+        "INSERT INTO users VALUES (1, 'hello');\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(td) / "marzban.sql"
+        dest = Path(td) / "fixed_import.sql"
+        src.write_text(sql, encoding="utf-8")
+        changed = rewrite_mysql_dump_file_for_pasarguard(src, dest)
+        assert changed >= 2
+        out = dest.read_text(encoding="utf-8")
+        assert out == fix_mysql_dump_for_pasarguard(sql)
+        assert "pasarguard" in out
+        assert "marzban" not in out.lower()
+        # in-place
+        changed_inplace = rewrite_mysql_dump_file_for_pasarguard(dest, dest)
+        assert changed_inplace == 0
+        assert dest.read_text(encoding="utf-8") == out
+    print("OK: mysql dump file rewrite streams")
 
 
 def test_read_env_var():
@@ -115,6 +144,7 @@ if __name__ == "__main__":
     test_mysql_env_uses_root_password()
     test_compose_transform()
     test_mysql_dump_fix()
+    test_mysql_dump_file_rewrite_streams()
     test_read_env_var()
     test_extract_env_password_candidates()
     test_url_replacement_survives_backslashes()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Marzban → PasarGuard same-family MySQL migrate could appear stuck at **~40%** (`Importing Marzban dump into PasarGuard mysql`) after the MySQL container started — especially with large dumps (~420 MB).

Cause:
1. Full dump loaded into Python memory for rewrite (`read_text` + global replace + `write_text`)
2. Import via silent `docker compose exec … mysql < dump` with **no logs / progress / ready wait**

Small dumps finished quickly; large ones looked hung.

## Fix (v2.2.7)

- Stream-rewrite dump files line-by-line (same rename behavior, no full-file RAM blowup)
- Wait for MySQL/MariaDB readiness (`mysqladmin ping` + `SELECT 1`) before wipe/import
- Import via `docker compose exec -T` **stdin** (not shell redirect)
- Progress heartbeats (45%→65%) + elapsed-time logs while import runs
- No short timeout on import (large dumps must be allowed to finish)

Light-dump migrations are unchanged in outcome; they just finish sooner.

## Version

Bump to **v2.2.7** (`APP_VERSION`, installer, UI cache bust, FA/EN/RU changelogs).

After merge: create GitHub release tag `v2.2.7` from `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe29f-e09f-758a-ac4e-97ce4da160e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe29f-e09f-758a-ac4e-97ce4da160e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

