### PR TITLE
Installer menu: install / uninstall / redirect server (v3.2.0)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v3.1.9`** — Always take a full backup before restore or migration.
+> ⚠️ **`v3.2.0`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -35,17 +35,38 @@ Web wizard for restore and migration to PasarGuard
 sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
 
-The installer asks which port the web panel should use — press Enter for the default `7000`.
-Re-running it keeps the port of the current install.
+The script clears the screen and opens a menu:
+
+| Option | What it does |
+|--------|--------------|
+| 1 · Install / update | Asks for the web panel port (Enter keeps `7000`), installs everything, then prints the panel URL |
+| 2 · Uninstall | Removes the service and `/opt/pg-migrator`, offering to keep your backups. PasarGuard, your databases and the redirect server stay untouched |
+| 3 · Redirect server | Status, restart, force restart and logs for `pg-redirect` — only used by 3x-ui / Hiddify migrations |
+| 4 · Exit | Leaves the menu |
+
+Above the menu the script shows PasarGuard (installed, version, database engine),
+Docker, the wizard service and the redirect server. When PasarGuard is missing it
+says so — install the panel first, this wizard only migrates data into it.
 
 URL: `http://SERVER_IP:PORT` (default `http://SERVER_IP:7000`)  
-Requirements: Ubuntu/Debian · root · Docker
+Requirements: Ubuntu/Debian · root · Docker · PasarGuard already installed
 
-Unattended install on a fixed port:
+### Old subscription links broken after a 3x-ui / Hiddify migration?
+
+`pg-redirect` has to bind the port the old panel used. If that panel is still
+running it keeps the port and the redirect service cannot start. Run the script,
+choose `3` (Redirect server) then `2` (Force restart): it stops the old panel,
+frees the ports and brings the redirect server back with a health check.
+
+### Unattended
 
 ```bash
 sudo PG_MIGRATOR_PORT=8443 bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
+sudo PG_MIGRATOR_ACTION=redirect-restart bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
+
+`PG_MIGRATOR_ACTION` accepts `install`, `uninstall`, `redirect-restart` or `menu`;
+add `PG_MIGRATOR_YES=1` to accept every confirmation.
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v3.1.8`** — Always take a full backup before restore or migration.
+> ⚠️ **`v3.1.9`** — Always take a full backup before restore or migration.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <b>English</b> · <a href="README.ru.md">Русский</a>
@@ -35,8 +35,17 @@ Web wizard for restore and migration to PasarGuard
 sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
 
-URL: `http://SERVER_IP:7000`  
+The installer asks which port the web panel should use — press Enter for the default `7000`.
+Re-running it keeps the port of the current install.
+
+URL: `http://SERVER_IP:PORT` (default `http://SERVER_IP:7000`)  
 Requirements: Ubuntu/Debian · root · Docker
+
+Unattended install on a fixed port:
+
+```bash
+sudo PG_MIGRATOR_PORT=8443 bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v3.1.8`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v3.1.9`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -37,8 +37,17 @@
 sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
 
-آدرس: `http://SERVER_IP:7000`  
+نصب‌کننده موقع نصب می‌پرسد وب‌پنل روی چه پورتی بالا بیاید — با زدن Enter همان `7000` پیش‌فرض می‌ماند.
+اگر دوباره نصب/آپدیت کنید، پورت فعلی حفظ می‌شود.
+
+آدرس: `http://SERVER_IP:PORT` (پیش‌فرض `http://SERVER_IP:7000`)  
 پیش‌نیاز: Ubuntu/Debian · root · Docker
+
+نصب بدون سوال، روی پورت دلخواه:
+
+```bash
+sudo PG_MIGRATOR_PORT=8443 bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> ⚠️ **`v3.1.9`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
+> ⚠️ **`v3.2.0`** — قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">
   <b>فارسی</b> · <a href="README.en.md">English</a> · <a href="README.ru.md">Русский</a>
@@ -37,17 +37,38 @@
 sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
 
-نصب‌کننده موقع نصب می‌پرسد وب‌پنل روی چه پورتی بالا بیاید — با زدن Enter همان `7000` پیش‌فرض می‌ماند.
-اگر دوباره نصب/آپدیت کنید، پورت فعلی حفظ می‌شود.
+اسکریپت صفحه را پاک می‌کند و یک منو نشان می‌دهد:
+
+| گزینه | کار |
+|-------|-----|
+| ۱ · Install / update | پورت وب‌پنل را می‌پرسد (Enter یعنی همان `7000`)، نصب را کامل انجام می‌دهد و در آخر آدرس ورود را می‌دهد |
+| ۲ · Uninstall | سرویس و `/opt/pg-migrator` را پاک می‌کند و پیشنهاد می‌دهد بکاپ‌ها را نگه دارد. پاسارگارد، دیتابیس‌ها و ریدایرکت سرور دست‌نخورده می‌مانند |
+| ۳ · Redirect server | وضعیت، ری‌استارت، ری‌استارت اجباری و لاگ سرویس `pg-redirect` — فقط برای مهاجرت 3x-ui و Hiddify |
+| ۴ · Exit | خروج از منو |
+
+بالای منو وضعیت پاسارگارد (نصب بودن، نسخه، نوع دیتابیس)، داکر، سرویس ویزارد و
+ریدایرکت سرور نمایش داده می‌شود. اگر پاسارگارد نصب نباشد پیام می‌دهد که اول باید
+پنل نصب شود؛ این ویزارد فقط داده را به پنل موجود منتقل می‌کند.
 
 آدرس: `http://SERVER_IP:PORT` (پیش‌فرض `http://SERVER_IP:7000`)  
-پیش‌نیاز: Ubuntu/Debian · root · Docker
+پیش‌نیاز: Ubuntu/Debian · root · Docker · پاسارگارد از قبل نصب‌شده
 
-نصب بدون سوال، روی پورت دلخواه:
+### بعد از مهاجرت 3x-ui / Hiddify لینک‌های قدیمی کار نمی‌کنند؟
+
+`pg-redirect` باید روی همان پورت پنل قبلی بالا بیاید. اگر پنل قبلی هنوز روشن باشد
+پورت را نگه می‌دارد و سرویس ریدایرکت بالا نمی‌آید. اسکریپت را اجرا کنید، گزینه `3`
+(Redirect server) و بعد `2` (Force restart): پنل قبلی را می‌خواباند، پورت‌ها را آزاد
+می‌کند و ریدایرکت را با health check دوباره بالا می‌آورد.
+
+### بدون سوال
 
 ```bash
 sudo PG_MIGRATOR_PORT=8443 bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
+sudo PG_MIGRATOR_ACTION=redirect-restart bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
+
+مقدارهای `PG_MIGRATOR_ACTION`: ‏`install`، `uninstall`، `redirect-restart` یا `menu`.
+با `PG_MIGRATOR_YES=1` همه تاییدها خودکار «بله» می‌شوند.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v3.1.9`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v3.2.0`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -35,17 +35,38 @@
 sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
 
-Установщик спрашивает порт веб-панели — Enter оставит порт по умолчанию `7000`.
-При повторном запуске сохраняется порт текущей установки.
+Скрипт очищает экран и показывает меню:
+
+| Пункт | Что делает |
+|-------|------------|
+| 1 · Install / update | Спрашивает порт веб-панели (Enter — `7000`), ставит всё и в конце печатает адрес входа |
+| 2 · Uninstall | Удаляет сервис и `/opt/pg-migrator`, предлагая сохранить бэкапы. PasarGuard, базы и redirect-сервер не трогает |
+| 3 · Redirect server | Статус, перезапуск, принудительный перезапуск и логи `pg-redirect` — только для миграций 3x-ui / Hiddify |
+| 4 · Exit | Выход из меню |
+
+Над меню видно состояние PasarGuard (установлен, версия, движок БД), Docker,
+сервиса мастера и redirect-сервера. Если PasarGuard не найден, скрипт скажет об
+этом: сначала установите панель, мастер только переносит данные в неё.
 
 Адрес: `http://SERVER_IP:PORT` (по умолчанию `http://SERVER_IP:7000`)  
-Требования: Ubuntu/Debian · root · Docker
+Требования: Ubuntu/Debian · root · Docker · установленный PasarGuard
 
-Установка без вопросов, на заданном порту:
+### После миграции 3x-ui / Hiddify не работают старые ссылки?
+
+`pg-redirect` должен занять порт старой панели. Если она всё ещё запущена, порт
+занят и сервис не стартует. Запустите скрипт, выберите `3` (Redirect server), затем
+`2` (Force restart): старая панель останавливается, порты освобождаются, redirect
+поднимается снова с проверкой здоровья.
+
+### Без вопросов
 
 ```bash
 sudo PG_MIGRATOR_PORT=8443 bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
+sudo PG_MIGRATOR_ACTION=redirect-restart bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
+
+`PG_MIGRATOR_ACTION`: `install`, `uninstall`, `redirect-restart` или `menu`;
+`PG_MIGRATOR_YES=1` подтверждает все вопросы.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> ⚠️ **`v3.1.8`** — Перед restore или миграцией сделайте полный бэкап.
+> ⚠️ **`v3.1.9`** — Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">
   <a href="README.md">فارسی</a> · <a href="README.en.md">English</a> · <b>Русский</b>
@@ -35,8 +35,17 @@
 sudo bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
 ```
 
-Адрес: `http://SERVER_IP:7000`  
+Установщик спрашивает порт веб-панели — Enter оставит порт по умолчанию `7000`.
+При повторном запуске сохраняется порт текущей установки.
+
+Адрес: `http://SERVER_IP:PORT` (по умолчанию `http://SERVER_IP:7000`)  
 Требования: Ubuntu/Debian · root · Docker
+
+Установка без вопросов, на заданном порту:
+
+```bash
+sudo PG_MIGRATOR_PORT=8443 bash -c "$(curl -fsSL 'https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh?v='$(date +%s))"
+```
 
 ---
 

--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,18 @@ XUI_DB_PATHS = [
 HIDDIFY_DIR = Path("/opt/hiddify-manager")
 HIDDIFY_MYSQL_PASS = HIDDIFY_DIR / "other/mysql/mysql_pass"
 
-WEB_PORT = 7000
+DEFAULT_WEB_PORT = 7000
+
+
+def _web_port() -> int:
+    """Port the installer chose for the wizard (systemd passes it in)."""
+    raw = os.environ.get("PG_MIGRATOR_PORT", "").strip()
+    if raw.isdigit() and 1 <= int(raw) <= 65535:
+        return int(raw)
+    return DEFAULT_WEB_PORT
+
+
+WEB_PORT = _web_port()
 
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 BACKUP_DIR.mkdir(parents=True, exist_ok=True)

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "3.1.9"
+APP_VERSION = "3.2.0"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,7 @@ from app.services.pg_restore import (
 from app.services.self_uninstall import uninstall_preview, schedule_self_uninstall
 from app.config import WEB_PORT
 
-APP_VERSION = "3.1.8"
+APP_VERSION = "3.1.9"
 app = FastAPI(title="PGClockMG", version=APP_VERSION)
 
 STATIC_DIR = Path(__file__).parent / "static"

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=3.1.9">
+  <link rel="stylesheet" href="/static/css/style.css?v=3.2.0">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v3.1.9</p>
+          <p class="header-version" id="appVersion">v3.2.0</p>
         </div>
       </div>
       <div class="header-meta">
@@ -590,9 +590,9 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=3.1.9"></script>
-  <script src="/static/js/app.js?v=3.1.9"></script>
-  <script src="/static/js/wizard-flow.js?v=3.1.9"></script>
+  <script src="/static/js/i18n.js?v=3.2.0"></script>
+  <script src="/static/js/app.js?v=3.2.0"></script>
+  <script src="/static/js/wizard-flow.js?v=3.2.0"></script>
 </body>
 </html>
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=3.1.8">
+  <link rel="stylesheet" href="/static/css/style.css?v=3.1.9">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v3.1.8</p>
+          <p class="header-version" id="appVersion">v3.1.9</p>
         </div>
       </div>
       <div class="header-meta">
@@ -590,9 +590,9 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=3.1.8"></script>
-  <script src="/static/js/app.js?v=3.1.8"></script>
-  <script src="/static/js/wizard-flow.js?v=3.1.8"></script>
+  <script src="/static/js/i18n.js?v=3.1.9"></script>
+  <script src="/static/js/app.js?v=3.1.9"></script>
+  <script src="/static/js/wizard-flow.js?v=3.1.9"></script>
 </body>
 </html>
 

--- a/install.sh
+++ b/install.sh
@@ -5,19 +5,24 @@
 # Usage:
 #   sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh)"
 #
+# PG_MIGRATOR_PORT=<port>       install non-interactively on that web port
+# PG_MIGRATOR_INSTALL_LIB=1     source the helpers only (used by the test suite)
+#
 set -eo pipefail
 
-readonly SCRIPT_VERSION="3.1.8"
+readonly SCRIPT_VERSION="3.1.9"
 readonly INSTALL_DIR="/opt/pg-migrator"
 readonly SERVICE_NAME="pg-migrator"
-readonly WEB_PORT=7000
+readonly DEFAULT_WEB_PORT=7000
+WEB_PORT="$DEFAULT_WEB_PORT"
+PREVIOUS_WEB_PORT=""
 readonly TOOLS_DIR="${INSTALL_DIR}/tools"
 readonly DEFAULT_REPO="https://github.com/Mrclocks/PGClockMG.git"
 readonly DEFAULT_INSTALL_URL="https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh"
 readonly REEXEC_MARKER="/tmp/.pg-migrator-reexec"
 readonly DEFAULT_BRANCH="main"
 
-if [[ ! -t 0 ]] && [[ ! -f "$REEXEC_MARKER" ]]; then
+if [[ "${PG_MIGRATOR_INSTALL_LIB:-0}" != "1" ]] && [[ ! -t 0 ]] && [[ ! -f "$REEXEC_MARKER" ]]; then
   tmpfile="$(mktemp /tmp/pg-migrator-install-XXXXXX.sh)"
   cleanup() { rm -f "$tmpfile" "$REEXEC_MARKER"; }
   trap cleanup EXIT
@@ -51,6 +56,103 @@ check_ubuntu() {
     . /etc/os-release
     [[ "${ID:-}" == "ubuntu" || "${ID_LIKE:-}" == *"debian"* ]] || warn "Not Ubuntu/Debian — may have issues"
   fi
+}
+
+valid_port() {
+  local p="${1:-}"
+  [[ "$p" =~ ^[0-9]{1,5}$ ]] || return 1
+  (( 10#$p >= 1 && 10#$p <= 65535 ))
+}
+
+port_in_use() {
+  local p="$1"
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnH 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${p}\$" && return 0
+    return 1
+  fi
+  if command -v netstat >/dev/null 2>&1; then
+    netstat -ltn 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${p}\$" && return 0
+  fi
+  return 1
+}
+
+# Port of an existing install, so re-running the installer keeps the user's choice.
+detect_installed_port() {
+  local unit="${1:-/etc/systemd/system/${SERVICE_NAME}.service}" p=""
+  [[ -f "$unit" ]] || return 0
+  p="$(grep -oE -- '--port[ =]+[0-9]+' "$unit" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)"
+  valid_port "$p" && printf '%s' "$p"
+  return 0
+}
+
+# stdin can be an already-drained pipe (curl | bash), so ask the terminal directly.
+ask_tty() {
+  local prompt="$1" __var="$2"
+  if [[ -t 0 ]]; then
+    read -r -p "$prompt" "$__var"
+  elif [[ -r /dev/tty ]]; then
+    read -r -p "$prompt" "$__var" < /dev/tty
+  else
+    return 1
+  fi
+}
+
+tty_available() { [[ -t 0 || -r /dev/tty ]]; }
+
+select_web_port() {
+  local default_port="$DEFAULT_WEB_PORT" answer attempt
+
+  PREVIOUS_WEB_PORT="$(detect_installed_port)"
+  [[ -n "$PREVIOUS_WEB_PORT" ]] && default_port="$PREVIOUS_WEB_PORT"
+
+  if [[ -n "${PG_MIGRATOR_PORT:-}" ]]; then
+    valid_port "${PG_MIGRATOR_PORT}" \
+      || fail "PG_MIGRATOR_PORT='${PG_MIGRATOR_PORT}' is not a valid port (1-65535)"
+    WEB_PORT="$((10#${PG_MIGRATOR_PORT}))"
+    ok "Web panel port ${WEB_PORT} (from PG_MIGRATOR_PORT)"
+    return
+  fi
+
+  if ! tty_available; then
+    WEB_PORT="$default_port"
+    warn "No terminal available for questions — using port ${WEB_PORT} (set PG_MIGRATOR_PORT to change)"
+    return
+  fi
+
+  log ""
+  log "  ${C_BOLD}Which port should the web panel listen on?${C_RESET}"
+  [[ -n "$PREVIOUS_WEB_PORT" ]] \
+    && log "  ${C_DIM}Current install uses ${PREVIOUS_WEB_PORT}. Press Enter to keep it.${C_RESET}" \
+    || log "  ${C_DIM}Press Enter for the default (${DEFAULT_WEB_PORT}).${C_RESET}"
+
+  for attempt in 1 2 3 4 5; do
+    answer=""
+    if ! ask_tty "  Port [${default_port}]: " answer; then
+      WEB_PORT="$default_port"
+      warn "Could not read the answer — using port ${WEB_PORT}"
+      return
+    fi
+    answer="${answer//[[:space:]]/}"
+    [[ -z "$answer" ]] && answer="$default_port"
+
+    if ! valid_port "$answer"; then
+      warn "'${answer}' is not a valid port. Enter a number between 1 and 65535."
+      continue
+    fi
+    answer="$((10#$answer))"
+
+    if [[ "$answer" != "${PREVIOUS_WEB_PORT}" ]] && port_in_use "$answer"; then
+      warn "Port ${answer} is already used by another service — pick a different one."
+      continue
+    fi
+
+    WEB_PORT="$answer"
+    ok "Web panel port: ${WEB_PORT}"
+    log ""
+    return
+  done
+
+  fail "No usable port chosen after 5 attempts — re-run with PG_MIGRATOR_PORT=<port>"
 }
 
 docker_available() { command -v docker >/dev/null 2>&1; }
@@ -172,6 +274,7 @@ Type=simple
 User=root
 WorkingDirectory=${INSTALL_DIR}
 Environment=PG_MIGRATOR_HOME=${INSTALL_DIR}
+Environment=PG_MIGRATOR_PORT=${WEB_PORT}
 Environment=PATH=${INSTALL_DIR}/venv/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=${INSTALL_DIR}/venv/bin/python -m uvicorn app.main:app --host 0.0.0.0 --port ${WEB_PORT}
 Restart=on-failure
@@ -192,6 +295,10 @@ open_firewall() {
   if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "active"; then
     ufw allow "${WEB_PORT}/tcp" >/dev/null 2>&1 || true
     ok "Firewall port ${WEB_PORT} opened"
+    if [[ -n "$PREVIOUS_WEB_PORT" && "$PREVIOUS_WEB_PORT" != "$WEB_PORT" ]]; then
+      ufw delete allow "${PREVIOUS_WEB_PORT}/tcp" >/dev/null 2>&1 || true
+      info "Firewall rule for old port ${PREVIOUS_WEB_PORT} removed"
+    fi
   fi
 }
 
@@ -221,6 +328,7 @@ main() {
   log ""
   require_root
   check_ubuntu
+  select_web_port
   install_packages
   install_uv
   copy_app_files
@@ -231,4 +339,6 @@ main() {
   print_success
 }
 
-main "$@"
+if [[ "${PG_MIGRATOR_INSTALL_LIB:-0}" != "1" ]]; then
+  main "$@"
+fi

--- a/install.sh
+++ b/install.sh
@@ -5,14 +5,24 @@
 # Usage:
 #   sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh)"
 #
-# PG_MIGRATOR_PORT=<port>       install non-interactively on that web port
-# PG_MIGRATOR_INSTALL_LIB=1     source the helpers only (used by the test suite)
+# Interactive menu: install / uninstall / redirect server / exit.
+#
+# Non-interactive:
+#   PG_MIGRATOR_ACTION=install|uninstall|redirect-restart|menu   (or pass as argv[1])
+#   PG_MIGRATOR_PORT=<port>       web panel port, no question asked
+#   PG_MIGRATOR_YES=1             answer every confirmation with yes
+#   PG_MIGRATOR_INSTALL_LIB=1     source the helpers only (used by the test suite)
+#
+# The test suite also redirects the paths it inspects with PG_MIGRATOR_INSTALL_DIR,
+# PG_MIGRATOR_SYSTEMD_DIR, PG_MIGRATOR_PASARGUARD_DIR and PG_MIGRATOR_REDIRECT_DIR.
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="3.1.9"
-readonly INSTALL_DIR="/opt/pg-migrator"
+readonly SCRIPT_VERSION="3.2.0"
+readonly INSTALL_DIR="${PG_MIGRATOR_INSTALL_DIR:-/opt/pg-migrator}"
 readonly SERVICE_NAME="pg-migrator"
+readonly SYSTEMD_DIR="${PG_MIGRATOR_SYSTEMD_DIR:-/etc/systemd/system}"
+readonly SERVICE_FILE="${SYSTEMD_DIR}/pg-migrator.service"
 readonly DEFAULT_WEB_PORT=7000
 WEB_PORT="$DEFAULT_WEB_PORT"
 PREVIOUS_WEB_PORT=""
@@ -21,6 +31,16 @@ readonly DEFAULT_REPO="https://github.com/Mrclocks/PGClockMG.git"
 readonly DEFAULT_INSTALL_URL="https://raw.githubusercontent.com/Mrclocks/PGClockMG/main/install.sh"
 readonly REEXEC_MARKER="/tmp/.pg-migrator-reexec"
 readonly DEFAULT_BRANCH="main"
+
+readonly PASARGUARD_DIR="${PG_MIGRATOR_PASARGUARD_DIR:-/opt/pasarguard}"
+readonly PASARGUARD_ENV="${PASARGUARD_DIR}/.env"
+readonly PASARGUARD_DOCS="https://docs.pasarguard.org/en/panel/installation/"
+
+readonly REDIRECT_SERVICE="pg-redirect"
+readonly REDIRECT_SERVICE_FILE="${SYSTEMD_DIR}/pg-redirect.service"
+readonly REDIRECT_CONFIG_DIR="${PG_MIGRATOR_REDIRECT_DIR:-/etc/pg-redirect}"
+readonly REDIRECT_CONFIG="${REDIRECT_CONFIG_DIR}/config.json"
+readonly REDIRECT_MAPPING="${REDIRECT_CONFIG_DIR}/mapping.json"
 
 if [[ "${PG_MIGRATOR_INSTALL_LIB:-0}" != "1" ]] && [[ ! -t 0 ]] && [[ ! -f "$REEXEC_MARKER" ]]; then
   tmpfile="$(mktemp /tmp/pg-migrator-install-XXXXXX.sh)"
@@ -37,6 +57,16 @@ fi
 
 set -u
 
+# The re-exec copy owns the marker; drop it (and itself) whenever the menu ends.
+if [[ "${PG_MIGRATOR_FROM_PIPE:-0}" == "1" ]]; then
+  trap 'rm -f "$REEXEC_MARKER" 2>/dev/null || true' EXIT
+fi
+
+# Every long-running probe below is wrapped in `timeout`; keep working without it.
+if ! command -v timeout >/dev/null 2>&1; then
+  timeout() { shift; "$@"; }
+fi
+
 C_RESET='\033[0m'; C_BOLD='\033[1m'; C_DIM='\033[2m'; C_GREEN='\033[32m'
 C_YELLOW='\033[33m'; C_CYAN='\033[36m'; C_RED='\033[31m'; C_WHITE='\033[97m'
 
@@ -45,6 +75,8 @@ ok()   { log "${C_GREEN}[OK]${C_RESET} $*"; }
 info() { log "${C_CYAN}[>>]${C_RESET} $*"; }
 warn() { log "${C_YELLOW}[!!]${C_RESET} $*"; }
 fail() { log "${C_RED}[ERR]${C_RESET} $*"; exit 1; }
+# Same message as fail(), but a menu action must not kill the whole script.
+fail_soft() { log "${C_RED}[ERR]${C_RESET} $*"; }
 
 require_root() {
   [[ "${EUID:-$(id -u)}" -eq 0 ]] || fail "Must run as root: sudo bash install.sh"
@@ -56,6 +88,97 @@ check_ubuntu() {
     . /etc/os-release
     [[ "${ID:-}" == "ubuntu" || "${ID_LIKE:-}" == *"debian"* ]] || warn "Not Ubuntu/Debian — may have issues"
   fi
+}
+
+# ── terminal input ────────────────────────────────────────────────────────────
+
+tty_available() { [[ -t 0 || -r /dev/tty ]]; }
+
+# stdin can be an already-drained pipe (curl | bash), so ask the terminal directly.
+ask_tty() {
+  local prompt="$1" __var="$2"
+  if [[ -t 0 ]]; then
+    read -r -p "$prompt" "$__var"
+  elif [[ -r /dev/tty ]]; then
+    read -r -p "$prompt" "$__var" < /dev/tty
+  else
+    return 1
+  fi
+}
+
+confirm() {
+  local question="$1" default="${2:-N}" answer hint
+  [[ "${PG_MIGRATOR_YES:-0}" == "1" ]] && return 0
+  [[ "$default" == "Y" ]] && hint="[Y/n]" || hint="[y/N]"
+  if ! tty_available; then
+    [[ "$default" == "Y" ]]
+    return
+  fi
+  if ! ask_tty "  ${question} ${hint}: " answer; then
+    [[ "$default" == "Y" ]]
+    return
+  fi
+  answer="${answer//[[:space:]]/}"
+  answer="${answer,,}"
+  [[ -z "$answer" ]] && answer="${default,,}"
+  [[ "$answer" == "y" || "$answer" == "yes" ]]
+}
+
+# Run a menu action without letting a failure kill the script.
+#
+# `action || true` looks equivalent but is not: bash disables errexit for the
+# whole command whose status is tested, and that state is inherited by the
+# functions and subshells it runs — a failing install step would then be
+# ignored and the next step would run anyway. Toggling the option around a
+# plain call keeps errexit effective inside the action.
+LAST_ACTION_RC=0
+run_action() {
+  set +e
+  "$@"
+  LAST_ACTION_RC=$?
+  set -e
+  return 0
+}
+
+pause_menu() {
+  local _ignored
+  tty_available || return 0
+  log ""
+  ask_tty "  Press Enter to return to the menu... " _ignored || true
+}
+
+# ── system probes ─────────────────────────────────────────────────────────────
+
+have_systemd() { command -v systemctl >/dev/null 2>&1; }
+docker_available() { command -v docker >/dev/null 2>&1; }
+docker_running()   { timeout 15 docker info >/dev/null 2>&1; }
+compose_available() { docker compose version >/dev/null 2>&1 || command -v docker-compose >/dev/null 2>&1; }
+
+unit_active() {
+  have_systemd || return 1
+  systemctl is-active --quiet "$1" 2>/dev/null
+}
+
+unit_enabled() {
+  have_systemd || return 1
+  [[ "$(systemctl is-enabled "$1" 2>/dev/null || true)" == "enabled" ]]
+}
+
+server_ip() {
+  local ip=""
+  ip="$(ip route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i < NF; i++) if ($i == "src") {print $(i + 1); exit}}' || true)"
+  [[ -z "$ip" ]] && ip="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+  printf '%s' "${ip:-SERVER_IP}"
+}
+
+# Last assignment of KEY in a .env style file, quotes stripped.
+env_value() {
+  local file="$1" key="$2"
+  [[ -f "$file" ]] || return 0
+  grep -E "^[[:space:]]*${key}[[:space:]]*=" "$file" 2>/dev/null \
+    | tail -1 \
+    | sed -E "s/^[^=]*=[[:space:]]*//; s/^[\"']//; s/[\"'][[:space:]]*$//" \
+    || true
 }
 
 valid_port() {
@@ -76,28 +199,369 @@ port_in_use() {
   return 1
 }
 
+# Kill whatever listens on a port using ss(8) alone (no fuser/lsof needed).
+kill_listeners() {
+  local p="$1" pids pid
+  command -v ss >/dev/null 2>&1 || return 0
+  pids="$(timeout 5 ss -lntp 2>/dev/null \
+    | grep -E "[:.]${p}[[:space:]]" \
+    | grep -oE 'pid=[0-9]+' \
+    | grep -oE '[0-9]+' \
+    | sort -u || true)"
+  for pid in $pids; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    (( pid > 1 )) || continue
+    [[ "$pid" == "$$" ]] && continue
+    kill -9 "$pid" 2>/dev/null || true
+  done
+}
+
+port_owner() {
+  local p="$1" owner=""
+  if command -v ss >/dev/null 2>&1; then
+    owner="$(timeout 5 ss -lntp 2>/dev/null | grep -E "[:.]${p}[[:space:]]" | grep -oE 'users:\(\("[^"]+"' | head -1 | grep -oE '"[^"]+"' | tr -d '"' || true)"
+  fi
+  printf '%s' "$owner"
+}
+
+# ── PGClockMG state ───────────────────────────────────────────────────────────
+
+pgclockmg_installed() { [[ -d "$INSTALL_DIR" || -f "$SERVICE_FILE" ]]; }
+
 # Port of an existing install, so re-running the installer keeps the user's choice.
 detect_installed_port() {
-  local unit="${1:-/etc/systemd/system/${SERVICE_NAME}.service}" p=""
+  local unit="${1:-$SERVICE_FILE}" p=""
   [[ -f "$unit" ]] || return 0
   p="$(grep -oE -- '--port[ =]+[0-9]+' "$unit" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)"
   valid_port "$p" && printf '%s' "$p"
   return 0
 }
 
-# stdin can be an already-drained pipe (curl | bash), so ask the terminal directly.
-ask_tty() {
-  local prompt="$1" __var="$2"
-  if [[ -t 0 ]]; then
-    read -r -p "$prompt" "$__var"
-  elif [[ -r /dev/tty ]]; then
-    read -r -p "$prompt" "$__var" < /dev/tty
+read_app_version() {
+  # Prefer version from the synced app (source of truth), not this installer banner alone.
+  local v=""
+  if [[ -f "${INSTALL_DIR}/app/main.py" ]]; then
+    v="$(grep -E '^APP_VERSION\s*=' "${INSTALL_DIR}/app/main.py" | head -1 | sed -E 's/.*["'"'"']([^"'"'"']+)["'"'"'].*/\1/' || true)"
+  fi
+  if [[ -n "$v" ]]; then
+    printf '%s' "$v"
   else
-    return 1
+    printf '%s' "$SCRIPT_VERSION"
   fi
 }
 
-tty_available() { [[ -t 0 || -r /dev/tty ]]; }
+# ── PasarGuard state ──────────────────────────────────────────────────────────
+
+pasarguard_installed() { [[ -d "$PASARGUARD_DIR" && -f "$PASARGUARD_ENV" ]]; }
+
+pasarguard_container() {
+  docker_available || return 0
+  timeout 8 docker ps --format '{{.Names}}' 2>/dev/null \
+    | grep -iE 'pasarguard' \
+    | grep -viE 'db|postgres|timescale|mysql|maria|redis|node' \
+    | head -1 || true
+}
+
+pasarguard_compose_db() {
+  local f
+  for f in "${PASARGUARD_DIR}/docker-compose.yml" "${PASARGUARD_DIR}/docker-compose.yaml"; do
+    [[ -f "$f" ]] || continue
+    grep -qiE '^[[:space:]]*image:.*timescale' "$f" && { printf 'timescaledb'; return 0; }
+    grep -qiE '^[[:space:]]*image:.*mariadb' "$f" && { printf 'mariadb'; return 0; }
+    grep -qiE '^[[:space:]]*image:.*(postgres|pgvector)' "$f" && { printf 'postgresql'; return 0; }
+    grep -qiE '^[[:space:]]*image:.*mysql' "$f" && { printf 'mysql'; return 0; }
+  done
+  return 0
+}
+
+# Mirrors app/services/env_migration.detect_db_type_from_env (stamp → URL → compose).
+pasarguard_db_type() {
+  local stamped url low compose
+  pasarguard_installed || return 0
+  stamped="$(env_value "$PASARGUARD_ENV" "PASARGUARD_DB_ENGINE" | tr '[:upper:]' '[:lower:]')"
+  case "$stamped" in
+    sqlite|mysql|mariadb|postgresql|timescaledb) printf '%s' "$stamped"; return 0 ;;
+  esac
+
+  url="$(env_value "$PASARGUARD_ENV" "SQLALCHEMY_DATABASE_URL")"
+  low="$(printf '%s' "$url" | tr '[:upper:]' '[:lower:]')"
+  compose="$(pasarguard_compose_db)"
+  case "$low" in
+    *sqlite*)    printf 'sqlite'; return 0 ;;
+    *mariadb*)   printf 'mariadb'; return 0 ;;
+    *timescale*) printf 'timescaledb'; return 0 ;;
+  esac
+  case "$low" in
+    *mysql*|*pymysql*|*asyncmy*)
+      case "$compose" in mysql|mariadb) printf '%s' "$compose" ;; *) printf 'mysql' ;; esac
+      return 0 ;;
+    *postgres*|*asyncpg*)
+      case "$compose" in timescaledb|postgresql) printf '%s' "$compose" ;; *) printf 'postgresql' ;; esac
+      return 0 ;;
+  esac
+  [[ -n "$compose" ]] && printf '%s' "$compose"
+  return 0
+}
+
+# Best effort: image label → image tag → compose file tag.
+pasarguard_version() {
+  local name="${1:-}" img tag v=""
+  if docker_available; then
+    [[ -n "$name" ]] || name="$(pasarguard_container)"
+    if [[ -n "$name" ]]; then
+      v="$(timeout 8 docker inspect -f '{{index .Config.Labels "org.opencontainers.image.version"}}' "$name" 2>/dev/null || true)"
+      [[ "$v" == "<no value>" ]] && v=""
+      if [[ -z "$v" ]]; then
+        img="$(timeout 8 docker inspect -f '{{.Config.Image}}' "$name" 2>/dev/null || true)"
+        tag="${img##*:}"
+        [[ "$tag" == "$img" || "$tag" == */* ]] && tag=""
+        v="$tag"
+      fi
+    fi
+  fi
+  if [[ -z "$v" ]]; then
+    local f
+    for f in "${PASARGUARD_DIR}/docker-compose.yml" "${PASARGUARD_DIR}/docker-compose.yaml"; do
+      [[ -f "$f" ]] || continue
+      # Only a real ":tag" at the end counts — an untagged image has no version.
+      v="$(grep -iE '^[[:space:]]*image:.*pasarguard' "$f" 2>/dev/null \
+        | head -1 \
+        | grep -oE ':[A-Za-z0-9_.+-]+[[:space:]]*$' \
+        | tr -d '[:space:]' \
+        | sed 's/^://' || true)"
+      [[ -n "$v" ]] && break
+    done
+  fi
+  printf '%s' "${v:-unknown}"
+}
+
+# ── pg-redirect state ─────────────────────────────────────────────────────────
+
+REDIRECT_PORT=""
+REDIRECT_EXTRA_PORTS=""
+REDIRECT_PANEL=""
+REDIRECT_SSL="false"
+REDIRECT_BASE=""
+
+redirect_configured() { [[ -f "$REDIRECT_CONFIG" || -f "$REDIRECT_SERVICE_FILE" ]]; }
+
+redirect_load_config() {
+  REDIRECT_PORT=""; REDIRECT_EXTRA_PORTS=""; REDIRECT_PANEL=""
+  REDIRECT_SSL="false"; REDIRECT_BASE=""
+  [[ -f "$REDIRECT_CONFIG" ]] || return 1
+
+  local parsed="" key value
+  if command -v python3 >/dev/null 2>&1; then
+    parsed="$(python3 - "$REDIRECT_CONFIG" <<'PY' 2>/dev/null || true
+import json, sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        cfg = json.load(fh)
+except Exception:
+    raise SystemExit(1)
+
+extras = []
+for raw in cfg.get("extra_ports") or []:
+    try:
+        extras.append(str(int(raw)))
+    except (TypeError, ValueError):
+        continue
+
+print("PORT=%s" % (cfg.get("port") or ""))
+print("EXTRA=%s" % " ".join(extras))
+print("PANEL=%s" % (cfg.get("panel") or ""))
+print("SSL=%s" % ("true" if (cfg.get("ssl") or {}).get("enabled") else "false"))
+print("BASE=%s" % (cfg.get("redirect_base") or ""))
+PY
+)"
+  fi
+  if [[ -z "$parsed" ]]; then
+    # Fallback for a server without python3 — enough for the status line.
+    REDIRECT_PORT="$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$REDIRECT_CONFIG" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)"
+    REDIRECT_PANEL="$(grep -oE '"panel"[[:space:]]*:[[:space:]]*"[^"]*"' "$REDIRECT_CONFIG" 2>/dev/null | head -1 | sed -E 's/.*"([^"]*)"$/\1/' || true)"
+    grep -qE '"enabled"[[:space:]]*:[[:space:]]*true' "$REDIRECT_CONFIG" 2>/dev/null && REDIRECT_SSL="true"
+    return 0
+  fi
+
+  while IFS='=' read -r key value; do
+    case "$key" in
+      PORT)  REDIRECT_PORT="$value" ;;
+      EXTRA) REDIRECT_EXTRA_PORTS="$value" ;;
+      PANEL) REDIRECT_PANEL="$value" ;;
+      SSL)   REDIRECT_SSL="$value" ;;
+      BASE)  REDIRECT_BASE="$value" ;;
+    esac
+  done <<< "$parsed"
+  return 0
+}
+
+redirect_all_ports() {
+  local out="${REDIRECT_PORT}"
+  [[ -n "$REDIRECT_EXTRA_PORTS" ]] && out="${out} ${REDIRECT_EXTRA_PORTS}"
+  printf '%s' "$out"
+}
+
+# "443 2083" -> "443, 2083"
+format_ports() {
+  local p out=""
+  for p in ${1:-}; do
+    [[ -n "$out" ]] && out="${out}, ${p}" || out="$p"
+  done
+  printf '%s' "$out"
+}
+
+# 0 = healthy, 1 = unhealthy, 2 = could not probe
+redirect_healthz() {
+  local port="$1" use_ssl="${2:-false}"
+  valid_port "$port" || return 2
+  command -v python3 >/dev/null 2>&1 || return 2
+  timeout 20 python3 - "$port" "$use_ssl" <<'PY' >/dev/null 2>&1
+import socket, ssl, sys
+
+port = int(sys.argv[1])
+use_ssl = sys.argv[2] == "true"
+req = b"GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+try:
+    raw = socket.create_connection(("127.0.0.1", port), timeout=5)
+    sock = raw
+    if use_ssl:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        sock = ctx.wrap_socket(raw, server_hostname="127.0.0.1")
+    sock.sendall(req)
+    data = sock.recv(256).decode("iso-8859-1", "replace")
+    sock.close()
+except Exception:
+    raise SystemExit(1)
+raise SystemExit(0 if "200" in data.split("\r\n", 1)[0] else 1)
+PY
+}
+
+# ── screen ────────────────────────────────────────────────────────────────────
+
+clear_screen() {
+  # Never wipe the scrollback when the output is a log file rather than a terminal.
+  [[ -t 1 || -r /dev/tty ]] || return 0
+  if command -v clear >/dev/null 2>&1; then
+    clear || true
+  else
+    printf '\033[2J\033[H'
+  fi
+}
+
+rule() { log "${C_DIM}  ────────────────────────────────────────────────────────────${C_RESET}"; }
+
+status_row() {
+  local state="$1" label="$2" value="$3" tag color
+  case "$state" in
+    ok)   tag=" OK " ; color="$C_GREEN"  ;;
+    warn) tag="WARN" ; color="$C_YELLOW" ;;
+    bad)  tag="MISS" ; color="$C_RED"    ;;
+    *)    tag=" -- " ; color="$C_DIM"    ;;
+  esac
+  printf '   %b[%s]%b  %-17s %b%s%b\n' \
+    "$color" "$tag" "$C_RESET" "$label" "$C_WHITE" "$value" "$C_RESET"
+}
+
+print_banner() {
+  log ""
+  log "${C_CYAN}  ╔══════════════════════════════════════════════════════════╗${C_RESET}"
+  log "${C_CYAN}  ║${C_RESET}   ${C_BOLD}${C_WHITE}PGClockMG${C_RESET}  ·  PasarGuard restore & migration wizard    ${C_CYAN}║${C_RESET}"
+  log "${C_CYAN}  ╚══════════════════════════════════════════════════════════╝${C_RESET}"
+}
+
+print_status() {
+  local app_ver port ip pg_container pg_ver pg_db redirect_state ports
+
+  ip="$(server_ip)"
+  log ""
+  log "   ${C_DIM}Installer${C_RESET} ${C_WHITE}${SCRIPT_VERSION}${C_RESET}   ${C_DIM}·${C_RESET}   ${C_DIM}Server${C_RESET} ${C_WHITE}${ip}${C_RESET}"
+  log ""
+  log "  ${C_BOLD}SYSTEM STATUS${C_RESET}"
+  rule
+
+  if pasarguard_installed; then
+    pg_container="$(pasarguard_container)"
+    pg_ver="$(pasarguard_version "$pg_container")"
+    pg_db="$(pasarguard_db_type)"
+    if [[ -n "$pg_container" ]]; then
+      status_row ok "PasarGuard" "installed · ${pg_ver} · running"
+    else
+      status_row warn "PasarGuard" "installed · ${pg_ver} · containers stopped"
+    fi
+    if [[ -n "$pg_db" ]]; then
+      status_row ok "Panel database" "$pg_db"
+    else
+      status_row warn "Panel database" "unknown — check ${PASARGUARD_ENV}"
+    fi
+  else
+    status_row bad "PasarGuard" "not installed"
+  fi
+
+  if docker_available && docker_running; then
+    status_row ok "Docker" "running"
+  elif docker_available; then
+    status_row warn "Docker" "installed but not running"
+  else
+    status_row bad "Docker" "not installed"
+  fi
+
+  if pgclockmg_installed; then
+    app_ver="$(read_app_version)"
+    port="$(detect_installed_port)"
+    [[ -z "$port" ]] && port="$DEFAULT_WEB_PORT"
+    if unit_active "$SERVICE_NAME"; then
+      status_row ok "Wizard" "v${app_ver} · http://${ip}:${port}"
+    else
+      status_row warn "Wizard" "v${app_ver} · port ${port} · service stopped"
+    fi
+  else
+    status_row none "Wizard" "not installed"
+  fi
+
+  if redirect_configured; then
+    redirect_load_config || true
+    ports="$(format_ports "$(redirect_all_ports)")"
+    ports="${ports:-unknown}"
+    redirect_state="${REDIRECT_PANEL:-unknown} · port ${ports}"
+    if unit_active "$REDIRECT_SERVICE"; then
+      status_row ok "Redirect server" "active · ${redirect_state}"
+    else
+      status_row warn "Redirect server" "stopped · ${redirect_state}"
+    fi
+  else
+    status_row none "Redirect server" "not configured"
+  fi
+
+  if ! pasarguard_installed; then
+    log ""
+    log "   ${C_YELLOW}PasarGuard was not found on this server.${C_RESET}"
+    log "   ${C_DIM}This wizard only restores and migrates data INTO an existing panel.${C_RESET}"
+    log "   ${C_DIM}Install PasarGuard first: ${PASARGUARD_DOCS}${C_RESET}"
+  fi
+}
+
+print_menu() {
+  log ""
+  log "  ${C_BOLD}MENU${C_RESET}"
+  rule
+  log "   ${C_CYAN}1${C_RESET})  Install / update the web panel"
+  log "   ${C_CYAN}2${C_RESET})  Uninstall the web panel"
+  log "   ${C_CYAN}3${C_RESET})  Redirect server  ${C_DIM}(3x-ui / Hiddify only)${C_RESET}"
+  log "   ${C_CYAN}4${C_RESET})  Exit"
+  log ""
+}
+
+show_home() {
+  clear_screen
+  print_banner
+  print_status
+  print_menu
+}
+
+# ── port question ─────────────────────────────────────────────────────────────
 
 select_web_port() {
   local default_port="$DEFAULT_WEB_PORT" answer attempt
@@ -155,9 +619,7 @@ select_web_port() {
   fail "No usable port chosen after 5 attempts — re-run with PG_MIGRATOR_PORT=<port>"
 }
 
-docker_available() { command -v docker >/dev/null 2>&1; }
-docker_running()   { docker info >/dev/null 2>&1; }
-compose_available() { docker compose version >/dev/null 2>&1 || command -v docker-compose >/dev/null 2>&1; }
+# ── install ───────────────────────────────────────────────────────────────────
 
 install_packages() {
   info "Installing system packages..."
@@ -228,19 +690,6 @@ copy_app_files() {
   ok "Application synced to ${INSTALL_DIR}"
 }
 
-read_app_version() {
-  # Prefer version from the synced app (source of truth), not this installer banner alone.
-  local v=""
-  if [[ -f "${INSTALL_DIR}/app/main.py" ]]; then
-    v="$(grep -E '^APP_VERSION\s*=' "${INSTALL_DIR}/app/main.py" | head -1 | sed -E 's/.*["'"'"']([^"'"'"']+)["'"'"'].*/\1/')"
-  fi
-  if [[ -n "$v" ]]; then
-    printf '%s' "$v"
-  else
-    printf '%s' "$SCRIPT_VERSION"
-  fi
-}
-
 clone_migration_tools() {
   info "Fetching PasarGuard official migration tools..."
   [[ -d "${TOOLS_DIR}/db-migrations" ]] || git clone --depth 1 https://github.com/PasarGuard/db-migrations.git "${TOOLS_DIR}/db-migrations" 2>/dev/null || warn "db-migrations clone failed"
@@ -263,7 +712,7 @@ setup_python_env() {
 
 create_systemd_service() {
   info "Creating systemd service..."
-  cat > "/etc/systemd/system/${SERVICE_NAME}.service" <<EOF
+  cat > "$SERVICE_FILE" <<EOF
 [Unit]
 Description=PGClockMG — PasarGuard restore & migration wizard
 After=network.target docker.service
@@ -304,31 +753,28 @@ open_firewall() {
 
 print_success() {
   local ip app_ver
-  ip="$(hostname -I 2>/dev/null | awk '{print $1}' || echo "SERVER_IP")"
+  ip="$(server_ip)"
   app_ver="$(read_app_version)"
-  rm -f "$REEXEC_MARKER"
   log ""
-  log "${C_CYAN}${C_BOLD}====================================================${C_RESET}"
-  log "${C_WHITE}${C_BOLD}  PGClockMG installed successfully!${C_RESET}"
-  log "${C_CYAN}${C_BOLD}====================================================${C_RESET}"
+  log "${C_GREEN}  ╔══════════════════════════════════════════════════════════╗${C_RESET}"
+  log "${C_GREEN}  ║${C_RESET}   ${C_BOLD}${C_WHITE}PGClockMG is installed and running${C_RESET}                     ${C_GREEN}║${C_RESET}"
+  log "${C_GREEN}  ╚══════════════════════════════════════════════════════════╝${C_RESET}"
   log ""
-  log "  ${C_GREEN}Web panel:${C_RESET}  http://${ip}:${WEB_PORT}"
-  log "  ${C_DIM}Version:${C_RESET}    ${app_ver}"
-  log "  ${C_DIM}Path:${C_RESET}       ${INSTALL_DIR}"
+  log "   ${C_BOLD}Web panel${C_RESET}   ${C_GREEN}http://${ip}:${WEB_PORT}${C_RESET}"
+  log "   ${C_DIM}Port${C_RESET}        ${WEB_PORT}"
+  log "   ${C_DIM}Version${C_RESET}     ${app_ver}"
+  log "   ${C_DIM}Path${C_RESET}        ${INSTALL_DIR}"
+  log "   ${C_DIM}Service${C_RESET}     systemctl status ${SERVICE_NAME}"
   log ""
-  log "  ${C_YELLOW}Next:${C_RESET} Open the URL above and follow the wizard."
-  log "  ${C_DIM}Note:${C_RESET}     This wizard does NOT install PasarGuard — only migrate/restore."
+  log "   ${C_YELLOW}Next:${C_RESET} open the URL above and follow the wizard."
+  if ! pasarguard_installed; then
+    log "   ${C_YELLOW}Note:${C_RESET} PasarGuard is not installed yet — install the panel before migrating."
+  fi
   log ""
 }
 
-main() {
-  log ""
-  log "${C_CYAN}${C_BOLD}  PGClockMG Installer${C_RESET}"
-  log "  ${C_DIM}installer script ${SCRIPT_VERSION} — app version shown after sync${C_RESET}"
-  log ""
-  require_root
+run_install() {
   check_ubuntu
-  select_web_port
   install_packages
   install_uv
   copy_app_files
@@ -336,7 +782,405 @@ main() {
   setup_python_env
   create_systemd_service
   open_firewall
-  print_success
+}
+
+action_install() {
+  local rc=0 errexit_was_on=""
+
+  log ""
+  log "  ${C_BOLD}INSTALL / UPDATE${C_RESET}"
+  rule
+  select_web_port
+  info "Starting installation — this takes a few minutes."
+  log ""
+
+  # Steps run in a subshell so `fail` inside one of them returns here instead
+  # of ending the script; `set -e` is re-armed inside it so the install stops
+  # at the first failing step (callers go through run_action, see above).
+  # Restore — never force — errexit, or returning non-zero would end the script.
+  case "$-" in *e*) errexit_was_on=1 ;; esac
+  set +e
+  ( set -e; run_install )
+  rc=$?
+  [[ -n "$errexit_was_on" ]] && set -e
+
+  if (( rc == 0 )); then
+    print_success
+    return 0
+  fi
+  log ""
+  fail_soft "Installation failed. Fix the error above and run the installer again."
+  return 1
+}
+
+# ── uninstall ─────────────────────────────────────────────────────────────────
+
+action_uninstall() {
+  local port backup_dir keep_dir
+
+  log ""
+  log "  ${C_BOLD}UNINSTALL${C_RESET}"
+  rule
+
+  if ! pgclockmg_installed; then
+    warn "PGClockMG is not installed on this server — nothing to remove."
+    return 0
+  fi
+
+  port="$(detect_installed_port)"
+  log "   This removes:"
+  log "     ${C_DIM}•${C_RESET} systemd service ${SERVICE_NAME}"
+  log "     ${C_DIM}•${C_RESET} ${INSTALL_DIR} (app, uploads, backups, logs)"
+  [[ -n "$port" ]] && log "     ${C_DIM}•${C_RESET} firewall rule for port ${port}"
+  log ""
+  log "   ${C_GREEN}Kept untouched:${C_RESET} PasarGuard, your databases and the redirect server."
+  log ""
+
+  confirm "Remove PGClockMG now?" N || { info "Cancelled — nothing was removed."; return 0; }
+
+  backup_dir="${INSTALL_DIR}/backups"
+  if [[ -d "$backup_dir" ]] && [[ -n "$(ls -A "$backup_dir" 2>/dev/null || true)" ]]; then
+    if confirm "Keep a copy of the backups folder?" Y; then
+      keep_dir="${PG_MIGRATOR_BACKUP_DIR:-/root}/pgclockmg-backups-$(date +%Y%m%d-%H%M%S)"
+      if mkdir -p "$keep_dir" 2>/dev/null && cp -a "${backup_dir}/." "${keep_dir}/" 2>/dev/null; then
+        ok "Backups copied to ${keep_dir}"
+      else
+        warn "Could not copy the backups to ${keep_dir}"
+        confirm "Continue and delete them with the app?" N \
+          || { info "Cancelled — nothing was removed."; return 0; }
+      fi
+    fi
+  fi
+
+  if have_systemd; then
+    systemctl stop "$SERVICE_NAME" >/dev/null 2>&1 || true
+    systemctl disable "$SERVICE_NAME" >/dev/null 2>&1 || true
+  fi
+  rm -f "$SERVICE_FILE"
+  have_systemd && systemctl daemon-reload >/dev/null 2>&1 || true
+  rm -rf "$INSTALL_DIR"
+
+  if [[ -n "$port" ]] && command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "active"; then
+    ufw delete allow "${port}/tcp" >/dev/null 2>&1 || true
+    info "Firewall rule for port ${port} removed"
+  fi
+
+  ok "PGClockMG removed."
+  if redirect_configured; then
+    log "   ${C_DIM}The redirect server (${REDIRECT_SERVICE}) is still installed and untouched.${C_RESET}"
+  fi
+}
+
+# ── redirect server ───────────────────────────────────────────────────────────
+
+redirect_summary() {
+  local ports health
+  redirect_load_config || true
+  ports="$(format_ports "$(redirect_all_ports)")"
+
+  log "   ${C_DIM}Panel${C_RESET}          ${REDIRECT_PANEL:-unknown}"
+  log "   ${C_DIM}Listen ports${C_RESET}   ${ports:-unknown}"
+  log "   ${C_DIM}TLS${C_RESET}            $([[ "$REDIRECT_SSL" == "true" ]] && echo "enabled" || echo "disabled")"
+  [[ -n "$REDIRECT_BASE" ]] && log "   ${C_DIM}Redirects to${C_RESET}   ${REDIRECT_BASE}"
+  log "   ${C_DIM}Config${C_RESET}         ${REDIRECT_CONFIG}"
+  [[ -f "$REDIRECT_MAPPING" ]] && log "   ${C_DIM}Mapping${C_RESET}        ${REDIRECT_MAPPING}"
+  log ""
+
+  if unit_active "$REDIRECT_SERVICE"; then
+    ok "Service ${REDIRECT_SERVICE} is active"
+  else
+    warn "Service ${REDIRECT_SERVICE} is not running"
+  fi
+  unit_enabled "$REDIRECT_SERVICE" && ok "Enabled at boot" || warn "Not enabled at boot"
+
+  if valid_port "$REDIRECT_PORT"; then
+    health=0
+    redirect_healthz "$REDIRECT_PORT" "$REDIRECT_SSL" || health=$?
+    case "$health" in
+      0) ok "Health check passed on port ${REDIRECT_PORT} — old subscription links are being redirected" ;;
+      1) warn "Health check failed on port ${REDIRECT_PORT} — use 'Force restart' below" ;;
+      *) info "Health check skipped (python3 not available)" ;;
+    esac
+  fi
+
+  redirect_show_port_owners
+}
+
+redirect_show_port_owners() {
+  local p owner ports
+  ports="$(redirect_all_ports)"
+  for p in $ports; do
+    valid_port "$p" || continue
+    owner="$(port_owner "$p")"
+    if [[ -n "$owner" && "$owner" != "python3" ]]; then
+      warn "Port ${p} is currently held by '${owner}' — that is usually the old panel"
+    fi
+  done
+}
+
+# Stop whatever still holds the redirect ports (the old panel the user forgot to shut down).
+redirect_free_ports() {
+  local ports p ids
+  ports="$(redirect_all_ports)"
+
+  info "Stopping panels that commonly keep these ports busy..."
+  if have_systemd; then
+    # Stop our own service first so systemd does not restart it mid-cleanup.
+    timeout 20 systemctl stop "$REDIRECT_SERVICE" >/dev/null 2>&1 || true
+    timeout 20 systemctl stop x-ui x-ui.service redirect-server >/dev/null 2>&1 || true
+  fi
+
+  if [[ "${REDIRECT_PANEL,,}" == "hiddify" ]] || [[ " ${ports} " == *" 443 "* ]]; then
+    info "Stopping the Hiddify web stack (panel / nginx / haproxy)..."
+    if have_systemd; then
+      timeout 30 systemctl disable --now \
+        hiddify-panel hiddify-nginx hiddify-haproxy hiddify-gateway \
+        nginx haproxy apache2 caddy >/dev/null 2>&1 || true
+    fi
+  fi
+
+  for p in $ports; do
+    valid_port "$p" || continue
+    if docker_available; then
+      ids="$(timeout 8 docker ps --format '{{.ID}} {{.Ports}}' 2>/dev/null | awk -v pp="$p" 'index($0, ":" pp "->") {print $1}' || true)"
+      if [[ -n "$ids" ]]; then
+        info "Stopping docker containers publishing :${p}"
+        # shellcheck disable=SC2086
+        timeout 25 docker stop -t 3 $ids >/dev/null 2>&1 || true
+      fi
+    fi
+    timeout 8 fuser -k "${p}/tcp" >/dev/null 2>&1 || true
+    if command -v lsof >/dev/null 2>&1; then
+      timeout 8 bash -c "lsof -ti tcp:${p} | xargs -r kill -9" >/dev/null 2>&1 || true
+    fi
+    # Minimal servers often ship neither psmisc nor lsof, but almost always ss.
+    if port_in_use "$p"; then
+      kill_listeners "$p"
+    fi
+  done
+  sleep 1
+  ok "Redirect ports released"
+}
+
+redirect_start_and_verify() {
+  local attempt health
+  have_systemd || { fail_soft "systemctl is not available on this server."; return 1; }
+
+  systemctl daemon-reload >/dev/null 2>&1 || true
+  systemctl enable "$REDIRECT_SERVICE" >/dev/null 2>&1 || true
+  systemctl restart "$REDIRECT_SERVICE" >/dev/null 2>&1 || true
+
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    if unit_active "$REDIRECT_SERVICE"; then
+      health=0
+      redirect_healthz "$REDIRECT_PORT" "$REDIRECT_SSL" || health=$?
+      if [[ "$health" == "0" || "$health" == "2" ]]; then
+        ok "Redirect server is active on port ${REDIRECT_PORT}"
+        [[ "$health" == "2" ]] && info "Health check skipped (python3 not available)"
+        [[ "$health" == "0" ]] && ok "Health check passed — old subscription links resolve again"
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+
+  fail_soft "Redirect server did not come up cleanly."
+  log ""
+  log "  ${C_DIM}Last log lines:${C_RESET}"
+  timeout 15 journalctl -u "$REDIRECT_SERVICE" -n 20 --no-pager 2>/dev/null || true
+  redirect_show_port_owners
+  return 1
+}
+
+action_redirect_cli_restart() {
+  if ! redirect_configured; then
+    fail_soft "No redirect server is configured — it is created by a 3x-ui / Hiddify migration."
+    return 1
+  fi
+  redirect_load_config || true
+  redirect_free_ports
+  redirect_start_and_verify
+}
+
+action_redirect_restart() {
+  log ""
+  info "Restarting ${REDIRECT_SERVICE}..."
+  redirect_load_config || true
+  if redirect_start_and_verify; then
+    return 0
+  fi
+  log ""
+  warn "Try 'Force restart' — it stops the old panel that is still holding the port."
+  return 1
+}
+
+action_redirect_force_restart() {
+  local ports
+  redirect_load_config || true
+  ports="$(redirect_all_ports)"
+
+  log ""
+  log "  ${C_BOLD}FORCE RESTART${C_RESET}"
+  rule
+  log "   Ports to free: ${C_WHITE}$(format_ports "$ports")${C_RESET}"
+  log "   This stops anything still listening on them, including:"
+  log "     ${C_DIM}•${C_RESET} 3x-ui (x-ui service)"
+  log "     ${C_DIM}•${C_RESET} Hiddify web stack (panel, nginx, haproxy) when port 443 is used"
+  log "     ${C_DIM}•${C_RESET} docker containers publishing those ports"
+  log ""
+  log "   ${C_GREEN}PasarGuard, your databases and migrated data are not touched.${C_RESET}"
+  log ""
+
+  confirm "Free the ports and restart the redirect server?" Y || { info "Cancelled."; return 0; }
+
+  redirect_free_ports
+  redirect_start_and_verify
+}
+
+action_redirect_stop() {
+  log ""
+  warn "Stopping the redirect server means old 3x-ui / Hiddify subscription links stop working."
+  confirm "Stop and disable ${REDIRECT_SERVICE}?" N || { info "Cancelled."; return 0; }
+  if have_systemd; then
+    systemctl disable --now "$REDIRECT_SERVICE" >/dev/null 2>&1 || true
+  fi
+  if unit_active "$REDIRECT_SERVICE"; then
+    fail_soft "Could not stop ${REDIRECT_SERVICE}."
+    return 1
+  fi
+  ok "Redirect server stopped and disabled."
+  log "   ${C_DIM}Start it again from this menu at any time.${C_RESET}"
+}
+
+action_redirect_logs() {
+  log ""
+  log "  ${C_BOLD}RECENT REDIRECT LOGS${C_RESET}"
+  rule
+  if have_systemd; then
+    timeout 20 journalctl -u "$REDIRECT_SERVICE" -n 40 --no-pager 2>/dev/null \
+      || warn "No logs available for ${REDIRECT_SERVICE}"
+  else
+    warn "systemctl is not available on this server."
+  fi
+}
+
+redirect_menu() {
+  local choice
+  while true; do
+    clear_screen
+    print_banner
+    log ""
+    log "  ${C_BOLD}REDIRECT SERVER${C_RESET}  ${C_DIM}(3x-ui / Hiddify migrations only)${C_RESET}"
+    rule
+    log "   ${C_DIM}Keeps old 3x-ui / Hiddify subscription links alive by redirecting${C_RESET}"
+    log "   ${C_DIM}them to PasarGuard. It fails to start when the old panel is still${C_RESET}"
+    log "   ${C_DIM}running and holding the same port.${C_RESET}"
+    log ""
+
+    if ! redirect_configured; then
+      warn "No redirect server is configured on this server."
+      log ""
+      log "   ${C_DIM}It is created automatically at the end of a 3x-ui or Hiddify${C_RESET}"
+      log "   ${C_DIM}migration, when you choose to keep the old subscription links.${C_RESET}"
+      pause_menu
+      return 0
+    fi
+
+    redirect_summary
+
+    log ""
+    log "  ${C_BOLD}ACTIONS${C_RESET}"
+    rule
+    log "   ${C_CYAN}1${C_RESET})  Restart redirect server"
+    log "   ${C_CYAN}2${C_RESET})  Force restart  ${C_DIM}(stop the old panel holding the port)${C_RESET}"
+    log "   ${C_CYAN}3${C_RESET})  Show recent logs"
+    log "   ${C_CYAN}4${C_RESET})  Stop and disable"
+    log "   ${C_CYAN}5${C_RESET})  Back to main menu"
+    log ""
+
+    choice=""
+    if ! ask_tty "  Select an option [1-5]: " choice; then
+      return 0
+    fi
+    choice="${choice//[[:space:]]/}"
+
+    case "$choice" in
+      1) run_action action_redirect_restart; pause_menu ;;
+      2) run_action action_redirect_force_restart; pause_menu ;;
+      3) run_action action_redirect_logs; pause_menu ;;
+      4) run_action action_redirect_stop; pause_menu ;;
+      5|q|Q|b|B) return 0 ;;
+      *) warn "Unknown option '${choice}'"; sleep 1 ;;
+    esac
+  done
+}
+
+# ── menu ──────────────────────────────────────────────────────────────────────
+
+menu_loop() {
+  local choice
+  while true; do
+    show_home
+    choice=""
+    if ! ask_tty "  Select an option [1-4]: " choice; then
+      log ""
+      return 0
+    fi
+    choice="${choice//[[:space:]]/}"
+
+    case "$choice" in
+      1) clear_screen; print_banner; run_action action_install; pause_menu ;;
+      2) clear_screen; print_banner; run_action action_uninstall; pause_menu ;;
+      3) redirect_menu ;;
+      4|q|Q|e|E)
+        log ""
+        log "  ${C_DIM}Bye.${C_RESET}"
+        log ""
+        return 0
+        ;;
+      *) warn "Unknown option '${choice}' — choose 1, 2, 3 or 4"; sleep 1 ;;
+    esac
+  done
+}
+
+main() {
+  local action="${1:-${PG_MIGRATOR_ACTION:-}}"
+
+  case "$action" in
+    install|uninstall|redirect|redirect-restart|menu|"") ;;
+    *) fail "Unknown command '${action}' — use: install | uninstall | redirect-restart | menu" ;;
+  esac
+
+  require_root
+
+  case "$action" in
+    install)
+      clear_screen; print_banner
+      run_action action_install
+      return "$LAST_ACTION_RC"
+      ;;
+    uninstall)
+      clear_screen; print_banner
+      run_action action_uninstall
+      return "$LAST_ACTION_RC"
+      ;;
+    redirect-restart|redirect)
+      clear_screen; print_banner
+      run_action action_redirect_cli_restart
+      return "$LAST_ACTION_RC"
+      ;;
+    *) ;;
+  esac
+
+  if ! tty_available; then
+    # curl | bash with no terminal attached keeps the classic behaviour: install.
+    print_banner
+    info "No terminal detected — running an unattended install."
+    run_action action_install
+    return "$LAST_ACTION_RC"
+  fi
+
+  menu_loop
 }
 
 if [[ "${PG_MIGRATOR_INSTALL_LIB:-0}" != "1" ]]; then

--- a/tests/test_install_menu.py
+++ b/tests/test_install_menu.py
@@ -1,0 +1,562 @@
+"""Menu, status panel and uninstall/redirect actions in install.sh.
+
+install.sh is sourced with PG_MIGRATOR_INSTALL_LIB=1 (helpers only, no install)
+and every path it inspects is redirected into a sandbox, so the real
+/opt/pasarguard, /etc/pg-redirect and systemd units are never touched. A pty
+stands in for the operator wherever the script asks a question.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pty
+import re
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = ROOT / "install.sh"
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class Sandbox:
+    """Fake server layout: PasarGuard, systemd units, wizard install, redirect."""
+
+    def __init__(self, tmp: str):
+        self.root = Path(tmp)
+        self.pasarguard = self.root / "pasarguard"
+        self.systemd = self.root / "systemd"
+        self.install = self.root / "install"
+        self.redirect = self.root / "redirect"
+        self.keep = self.root / "keep"
+        for path in (self.pasarguard, self.systemd, self.install, self.redirect):
+            path.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def env(self) -> dict:
+        base = {k: v for k, v in os.environ.items() if not k.startswith("PG_MIGRATOR_")}
+        return {
+            **base,
+            "PG_MIGRATOR_INSTALL_LIB": "1",
+            "PG_MIGRATOR_INSTALL_DIR": str(self.install),
+            "PG_MIGRATOR_SYSTEMD_DIR": str(self.systemd),
+            "PG_MIGRATOR_PASARGUARD_DIR": str(self.pasarguard),
+            "PG_MIGRATOR_REDIRECT_DIR": str(self.redirect),
+            "PG_MIGRATOR_BACKUP_DIR": str(self.keep),
+        }
+
+    def write_pasarguard(self, env_text: str, compose: str | None = None) -> None:
+        (self.pasarguard / ".env").write_text(env_text, encoding="utf-8")
+        if compose is not None:
+            (self.pasarguard / "docker-compose.yml").write_text(compose, encoding="utf-8")
+
+    def write_wizard(self, version: str = "9.9.9", port: int = 8443) -> None:
+        (self.install / "app").mkdir(parents=True, exist_ok=True)
+        (self.install / "app" / "main.py").write_text(
+            f'APP_VERSION = "{version}"\n', encoding="utf-8"
+        )
+        (self.systemd / "pg-migrator.service").write_text(
+            "[Service]\n"
+            "ExecStart=/opt/pg-migrator/venv/bin/python -m uvicorn app.main:app "
+            f"--host 0.0.0.0 --port {port}\n",
+            encoding="utf-8",
+        )
+
+    def write_redirect(self, **cfg) -> None:
+        config = {
+            "host": "0.0.0.0",
+            "port": 2096,
+            "extra_ports": [],
+            "redirect_base": "https://panel.example.com:8000",
+            "panel": "x-ui",
+            "ssl": {"enabled": False},
+        }
+        config.update(cfg)
+        (self.redirect / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        (self.redirect / "mapping.json").write_text("{}", encoding="utf-8")
+        (self.systemd / "pg-redirect.service").write_text("[Service]\n", encoding="utf-8")
+
+    def run(self, snippet: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", "-c", f'source "{INSTALL_SH}"\n{snippet}'],
+            capture_output=True,
+            text=True,
+            env={**self.env, **(extra_env or {})},
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,  # no controlling terminal -> non-interactive path
+            timeout=120,
+        )
+
+    def run_on_tty(
+        self,
+        snippet: str,
+        keystrokes: list[str],
+        extra_env: dict | None = None,
+        settle: float = 1.0,
+    ) -> tuple[int, str]:
+        master, slave = pty.openpty()
+        try:
+            proc = subprocess.Popen(
+                ["bash", "-c", f'source "{INSTALL_SH}"\n{snippet}'],
+                stdin=slave,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env={**self.env, **(extra_env or {})},
+            )
+            for keys in keystrokes:
+                os.write(master, keys.encode())
+                time.sleep(settle)
+            out, _ = proc.communicate(timeout=180)
+            return proc.returncode, ANSI.sub("", out)
+        finally:
+            os.close(master)
+            os.close(slave)
+
+
+def plain(text: str) -> str:
+    return ANSI.sub("", text)
+
+
+def sandbox() -> tempfile.TemporaryDirectory:
+    return tempfile.TemporaryDirectory()
+
+
+# ── status panel ──────────────────────────────────────────────────────────────
+
+
+def test_pasarguard_database_detection():
+    cases = [
+        ('SQLALCHEMY_DATABASE_URL="sqlite+aiosqlite:////var/lib/pasarguard/db.sqlite3"', None, "sqlite"),
+        (
+            'SQLALCHEMY_DATABASE_URL="postgresql+asyncpg://u:p@db:5432/pg"',
+            "services:\n  timescaledb:\n    image: timescale/timescaledb-ha:pg17\n",
+            "timescaledb",
+        ),
+        (
+            'SQLALCHEMY_DATABASE_URL="postgresql+asyncpg://u:p@db:5432/pg"',
+            "services:\n  db:\n    image: postgres:16\n",
+            "postgresql",
+        ),
+        (
+            'SQLALCHEMY_DATABASE_URL="mysql+asyncmy://u:p@db/pg"',
+            "services:\n  db:\n    image: mariadb:11\n",
+            "mariadb",
+        ),
+        (
+            'PASARGUARD_DB_ENGINE=timescaledb\nSQLALCHEMY_DATABASE_URL="sqlite:////x.db"',
+            None,
+            "timescaledb",
+        ),
+    ]
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        for env_text, compose, expected in cases:
+            (box.pasarguard / "docker-compose.yml").unlink(missing_ok=True)
+            box.write_pasarguard(env_text + "\n", compose)
+            res = box.run("pasarguard_db_type; echo")
+            assert res.stdout.strip() == expected, f"{env_text} -> {res.stdout!r}"
+    print("OK: PasarGuard database engine detection")
+
+
+def test_pasarguard_version_from_compose():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_pasarguard(
+            'SQLALCHEMY_DATABASE_URL="sqlite:////x.db"\n',
+            "services:\n  pasarguard:\n    image: ghcr.io/pasarguard/panel:v1.4.2\n",
+        )
+        res = box.run("pasarguard_version; echo")
+        assert res.stdout.strip() == "v1.4.2", res.stdout
+
+        # An untagged image carries no version — say "unknown", never a raw yaml line
+        (box.pasarguard / "docker-compose.yml").write_text(
+            "services:\n  pasarguard:\n    image: pasarguard/panel\n", encoding="utf-8"
+        )
+        res = box.run("pasarguard_version; echo")
+        assert res.stdout.strip() == "unknown", res.stdout
+
+        (box.pasarguard / "docker-compose.yml").unlink()
+        res = box.run("pasarguard_version; echo")
+        assert res.stdout.strip() == "unknown", res.stdout
+    print("OK: PasarGuard version detection")
+
+
+def test_status_panel_reports_installed_stack():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_pasarguard(
+            'SQLALCHEMY_DATABASE_URL="postgresql+asyncpg://u:p@db/pg"\n',
+            "services:\n  pasarguard:\n    image: ghcr.io/pasarguard/panel:v1.4.2\n"
+            "  timescaledb:\n    image: timescale/timescaledb-ha:pg17\n",
+        )
+        box.write_wizard(version="3.2.0", port=8443)
+        box.write_redirect(port=443, extra_ports=[2083], panel="hiddify", ssl={"enabled": True})
+
+        out = plain(box.run("print_status").stdout)
+        assert "PasarGuard" in out and "v1.4.2" in out
+        assert "timescaledb" in out
+        assert "3.2.0" in out and "8443" in out
+        assert "hiddify" in out and "443, 2083" in out
+        assert "Installer" in out
+        assert "was not found" not in out
+    print("OK: status panel lists panel, database, wizard and redirect")
+
+
+def test_status_panel_warns_when_pasarguard_missing():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        out = plain(box.run("print_status").stdout)
+        assert "[MISS]" in out
+        assert "PasarGuard was not found" in out
+        assert "docs.pasarguard.org" in out
+        assert "not installed" in out
+    print("OK: missing PasarGuard is reported in English with an install hint")
+
+
+def test_menu_lists_the_four_entries():
+    with sandbox() as tmp:
+        out = plain(Sandbox(tmp).run("print_menu").stdout)
+        for entry in (
+            "1)  Install / update the web panel",
+            "2)  Uninstall the web panel",
+            "3)  Redirect server",
+            "4)  Exit",
+        ):
+            assert entry in out, out
+    print("OK: main menu shows install / uninstall / redirect / exit")
+
+
+# ── install action ────────────────────────────────────────────────────────────
+
+
+def test_install_asks_the_port_then_installs_and_prints_the_url():
+    """run_install is stubbed out — this covers the question → install → URL flow."""
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_wizard(version="3.2.0", port=7000)
+        code, out = box.run_on_tty(
+            "run_install() { echo '[fake] installing...'; }\naction_install",
+            ["8443\n"],
+        )
+        assert code == 0, out
+        assert "Which port should the web panel listen on?" in out, out
+        assert "[fake] installing..." in out, out
+        assert "PGClockMG is installed and running" in out, out
+        assert re.search(r"Web panel\s+http://\S+:8443", out), out
+        assert "Port        8443" in out, out
+    print("OK: install asks the port, installs, then shows the panel URL")
+
+
+def test_install_failure_is_reported_without_killing_the_menu():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        res = box.run(
+            "run_install() { echo boom >&2; return 1; }\n"
+            "action_install || echo 'RETURNED-TO-MENU'",
+            {"PG_MIGRATOR_PORT": "9099"},
+        )
+        out = plain(res.stdout + res.stderr)
+        assert res.returncode == 0, out
+        assert "Installation failed" in out, out
+        assert "RETURNED-TO-MENU" in out, out
+        assert "is installed and running" not in out, out
+    print("OK: a failed install returns to the menu instead of exiting")
+
+
+def test_install_stops_at_the_first_failing_step():
+    """errexit must stay armed inside the subshell that runs the install steps."""
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        res = box.run(
+            "run_install() { echo 'step one'; false; echo 'step two'; }\n"
+            "run_action action_install\n"
+            'echo "rc=$LAST_ACTION_RC"',
+            {"PG_MIGRATOR_PORT": "9098"},
+        )
+        out = plain(res.stdout + res.stderr)
+        assert res.returncode == 0, out
+        assert "step one" in out, out
+        assert "step two" not in out, out
+        assert "Installation failed" in out, out
+        assert "rc=1" in out, out
+    print("OK: the install aborts on the first failing step")
+
+
+# ── redirect server ───────────────────────────────────────────────────────────
+
+
+def test_redirect_config_is_parsed():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_redirect(
+            port=443,
+            extra_ports=[2083, 2087],
+            panel="hiddify",
+            ssl={"enabled": True},
+            redirect_base="https://pg.example.com:8000",
+        )
+        res = box.run(
+            'redirect_load_config\n'
+            'echo "port=$REDIRECT_PORT"\n'
+            'echo "extra=$REDIRECT_EXTRA_PORTS"\n'
+            'echo "panel=$REDIRECT_PANEL"\n'
+            'echo "ssl=$REDIRECT_SSL"\n'
+            'echo "base=$REDIRECT_BASE"\n'
+            'echo "all=$(redirect_all_ports)"\n'
+            'echo "pretty=$(format_ports "$(redirect_all_ports)")"'
+        )
+        out = res.stdout
+        assert "port=443" in out, out
+        assert "extra=2083 2087" in out, out
+        assert "panel=hiddify" in out, out
+        assert "ssl=true" in out, out
+        assert "base=https://pg.example.com:8000" in out, out
+        assert "all=443 2083 2087" in out, out
+        assert "pretty=443, 2083, 2087" in out, out
+    print("OK: redirect config parsing")
+
+
+def test_redirect_menu_without_config_explains_itself():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        code, out = box.run_on_tty("redirect_menu", ["\n"])
+        assert code == 0, out
+        assert "No redirect server is configured" in out, out
+        assert "3x-ui or Hiddify" in out, out
+    print("OK: redirect menu explains when nothing is configured")
+
+
+def test_redirect_menu_shows_actions_and_returns():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_redirect(port=59987, panel="x-ui")
+        code, out = box.run_on_tty("redirect_menu", ["5\n"])
+        assert code == 0, out
+        assert "REDIRECT SERVER" in out
+        assert "Restart redirect server" in out
+        assert "Force restart" in out
+        assert "Show recent logs" in out
+        assert "Stop and disable" in out
+        assert "x-ui" in out and "59987" in out
+    print("OK: redirect menu renders status and actions")
+
+
+def test_force_restart_can_be_declined():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_redirect(port=59986, panel="x-ui")
+        code, out = box.run_on_tty("action_redirect_force_restart", ["n\n"])
+        assert code == 0, out
+        assert "Ports to free: 59986" in out, out
+        assert "PasarGuard, your databases and migrated data are not touched" in out, out
+        assert "Cancelled" in out, out
+    print("OK: force restart asks before stopping the old panel")
+
+
+def test_free_ports_is_safe_without_systemd_or_docker():
+    """The sandbox has no systemd/docker — the helper must finish, not crash."""
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_redirect(port=59985, extra_ports=[59984], panel="x-ui")
+        res = box.run("redirect_load_config; redirect_free_ports")
+        assert res.returncode == 0, res.stdout + res.stderr
+        assert "Redirect ports released" in plain(res.stdout), res.stdout
+    print("OK: freeing the redirect ports degrades gracefully")
+
+
+def test_free_ports_kills_a_process_holding_the_port():
+    """The old panel is simulated by a listener the script has to clear out."""
+    import socket
+    import sys
+
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+
+        holder = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import socket,time;"
+                "s=socket.socket();s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);"
+                f"s.bind(('0.0.0.0',{port}));s.listen(5);time.sleep(120)",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            time.sleep(1.5)
+            box.write_redirect(port=port, panel="x-ui")
+            res = box.run("redirect_load_config; redirect_free_ports")
+            assert res.returncode == 0, res.stdout + res.stderr
+            time.sleep(1)
+            assert holder.poll() is not None, "the process holding the port should be gone"
+        finally:
+            if holder.poll() is None:
+                holder.kill()
+            holder.wait(timeout=10)
+    print("OK: force restart clears a process squatting on the redirect port")
+
+
+def test_healthz_probe_reports_dead_port():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        res = box.run("rc=0; redirect_healthz 59983 false || rc=$?; echo rc=$rc")
+        assert "rc=1" in res.stdout, res.stdout
+    print("OK: redirect health probe detects a dead port")
+
+
+# ── uninstall ─────────────────────────────────────────────────────────────────
+
+
+def test_uninstall_removes_service_and_keeps_backups():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_wizard(port=8443)
+        box.write_redirect(port=2096, panel="x-ui")
+        backups = box.install / "backups"
+        backups.mkdir(parents=True, exist_ok=True)
+        (backups / "pg-backup.tar").write_text("data", encoding="utf-8")
+
+        res = box.run("action_uninstall", {"PG_MIGRATOR_YES": "1"})
+        out = plain(res.stdout)
+        assert res.returncode == 0, out + res.stderr
+        assert "PGClockMG removed." in out, out
+        assert not box.install.exists(), "install dir should be gone"
+        assert not (box.systemd / "pg-migrator.service").exists(), "unit should be gone"
+
+        kept = list(box.keep.glob("pgclockmg-backups-*/pg-backup.tar"))
+        assert kept, "backups should be copied out before deletion"
+
+        # migration artefacts stay untouched
+        assert (box.redirect / "config.json").exists()
+        assert (box.systemd / "pg-redirect.service").exists()
+        assert "still installed and untouched" in out
+    print("OK: uninstall removes the wizard, keeps backups and the redirect server")
+
+
+def test_uninstall_is_a_noop_when_not_installed():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.install.rmdir()
+        res = box.run("action_uninstall", {"PG_MIGRATOR_YES": "1"})
+        assert res.returncode == 0, res.stdout + res.stderr
+        assert "nothing to remove" in plain(res.stdout), res.stdout
+    print("OK: uninstall on a clean server does nothing")
+
+
+def test_uninstall_can_be_declined():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_wizard()
+        code, out = box.run_on_tty("action_uninstall", ["n\n"])
+        assert code == 0, out
+        assert "nothing was removed" in out, out
+        assert box.install.exists()
+        assert (box.systemd / "pg-migrator.service").exists()
+    print("OK: uninstall requires an explicit yes")
+
+
+# ── menu loop & dispatch ──────────────────────────────────────────────────────
+
+
+def test_menu_loop_rejects_unknown_option_then_exits():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        code, out = box.run_on_tty("menu_loop", ["x\n", "4\n"], settle=2.0)
+        assert code == 0, out
+        assert "Unknown option 'x'" in out, out
+        assert "Bye." in out, out
+    print("OK: menu loop handles a wrong answer and exits cleanly")
+
+
+def test_menu_loop_opens_the_redirect_screen():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        box.write_redirect(port=59982, panel="x-ui")
+        code, out = box.run_on_tty("menu_loop", ["3\n", "5\n", "4\n"], settle=1.5)
+        assert code == 0, out
+        assert "REDIRECT SERVER" in out, out
+        assert "SYSTEM STATUS" in out, out
+    print("OK: option 3 opens and leaves the redirect screen")
+
+
+def test_menu_install_flow_end_to_end():
+    """Menu → port question → install → success screen → back to the menu."""
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        code, out = box.run_on_tty(
+            "run_install() { echo '[fake] installing...'; }\nmenu_loop",
+            ["1\n", "8443\n", "\n", "4\n"],
+            settle=1.5,
+        )
+        assert code == 0, out
+        assert "[fake] installing..." in out, out
+        assert re.search(r"Web panel\s+http://\S+:8443", out), out
+        assert "Press Enter to return to the menu" in out, out
+        assert out.rstrip().endswith("Bye."), out[-200:]
+    print("OK: install can be driven from the menu and returns to it")
+
+
+def test_cli_redirect_restart_needs_a_configured_redirect():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        res = box.run('run_action action_redirect_cli_restart; echo "rc=$LAST_ACTION_RC"')
+        out = plain(res.stdout + res.stderr)
+        assert res.returncode == 0, out
+        assert "No redirect server is configured" in out, out
+        assert "rc=1" in out, out
+    print("OK: redirect-restart reports a missing redirect setup")
+
+
+def test_unknown_cli_action_is_rejected():
+    with sandbox() as tmp:
+        box = Sandbox(tmp)
+        # main() is only defined when the script is not sourced as a library
+        code, out = box.run_on_tty(
+            "main bogus-action", [], {"PG_MIGRATOR_INSTALL_LIB": "1"}
+        )
+        assert code != 0, out
+        assert "Unknown command 'bogus-action'" in out, out
+    print("OK: an unknown CLI action is rejected before anything runs")
+
+
+def test_install_sh_still_syntax_checks():
+    res = subprocess.run(["bash", "-n", str(INSTALL_SH)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+    print("OK: install.sh parses")
+
+
+if __name__ == "__main__":
+    test_pasarguard_database_detection()
+    test_pasarguard_version_from_compose()
+    test_status_panel_reports_installed_stack()
+    test_status_panel_warns_when_pasarguard_missing()
+    test_menu_lists_the_four_entries()
+    test_install_asks_the_port_then_installs_and_prints_the_url()
+    test_install_failure_is_reported_without_killing_the_menu()
+    test_install_stops_at_the_first_failing_step()
+    test_redirect_config_is_parsed()
+    test_redirect_menu_without_config_explains_itself()
+    test_redirect_menu_shows_actions_and_returns()
+    test_force_restart_can_be_declined()
+    test_free_ports_is_safe_without_systemd_or_docker()
+    test_free_ports_kills_a_process_holding_the_port()
+    test_healthz_probe_reports_dead_port()
+    test_uninstall_removes_service_and_keeps_backups()
+    test_uninstall_is_a_noop_when_not_installed()
+    test_uninstall_can_be_declined()
+    test_menu_loop_rejects_unknown_option_then_exits()
+    test_menu_loop_opens_the_redirect_screen()
+    test_menu_install_flow_end_to_end()
+    test_cli_redirect_restart_needs_a_configured_redirect()
+    test_unknown_cli_action_is_rejected()
+    test_install_sh_still_syntax_checks()
+    print("\nAll install menu tests passed.")

--- a/tests/test_install_port.py
+++ b/tests/test_install_port.py
@@ -1,0 +1,188 @@
+"""Web-panel port selection in install.sh.
+
+The installer asks which port the wizard should listen on. Sourcing the script
+with PG_MIGRATOR_INSTALL_LIB=1 loads the helpers without running the install, so
+the prompt logic can be exercised here (a pty stands in for the operator).
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = ROOT / "install.sh"
+
+
+def _env(extra: dict | None) -> dict:
+    base = {k: v for k, v in os.environ.items() if k != "PG_MIGRATOR_PORT"}
+    return {**base, "PG_MIGRATOR_INSTALL_LIB": "1", **(extra or {})}
+
+
+def run_bash(snippet: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Source install.sh as a library, then run `snippet` against its helpers."""
+    full_env = _env(env)
+    return subprocess.run(
+        ["bash", "-c", f'source "{INSTALL_SH}"\n{snippet}'],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        start_new_session=True,  # no controlling terminal -> /dev/tty is unusable
+    )
+
+
+def run_bash_on_tty(snippet: str, keystrokes: str, env: dict | None = None) -> tuple[int, str]:
+    """Same, but stdin is a pty so the script takes its interactive path."""
+    full_env = _env(env)
+    master, slave = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            ["bash", "-c", f'source "{INSTALL_SH}"\n{snippet}'],
+            stdin=slave,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=full_env,
+        )
+        os.write(master, keystrokes.encode())
+        out, _ = proc.communicate(timeout=30)
+        return proc.returncode, out
+    finally:
+        os.close(master)
+        os.close(slave)
+
+
+def test_valid_port_accepts_and_rejects():
+    for good in ("1", "80", "7000", "8443", "65535"):
+        assert run_bash(f'valid_port "{good}"').returncode == 0, good
+    for bad in ("", "0", "65536", "-1", "70o0", "8080a", "1.5", "99999999"):
+        assert run_bash(f'valid_port "{bad}"').returncode != 0, bad
+    print("OK: valid_port range check")
+
+
+def test_detect_installed_port_reads_existing_unit():
+    with tempfile.TemporaryDirectory() as tmp:
+        unit = Path(tmp) / "pg-migrator.service"
+        unit.write_text(
+            "[Service]\n"
+            "ExecStart=/opt/pg-migrator/venv/bin/python -m uvicorn app.main:app "
+            "--host 0.0.0.0 --port 8443\n",
+            encoding="utf-8",
+        )
+        res = run_bash(f'detect_installed_port "{unit}"')
+        assert res.stdout.strip() == "8443", res.stdout
+
+        missing = run_bash(f'detect_installed_port "{tmp}/nope.service"')
+        assert missing.returncode == 0 and missing.stdout.strip() == ""
+    print("OK: detect_installed_port keeps the previous port")
+
+
+def test_env_var_selects_port_without_prompting():
+    res = run_bash('select_web_port >/dev/null; echo "$WEB_PORT"', {"PG_MIGRATOR_PORT": "8443"})
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == "8443", res.stdout
+    print("OK: PG_MIGRATOR_PORT drives non-interactive installs")
+
+
+def test_invalid_env_var_aborts_install():
+    res = run_bash('select_web_port; echo "$WEB_PORT"', {"PG_MIGRATOR_PORT": "not-a-port"})
+    assert res.returncode != 0, res.stdout
+    assert "not a valid port" in res.stdout + res.stderr
+    print("OK: invalid PG_MIGRATOR_PORT fails loudly")
+
+
+def test_no_terminal_falls_back_to_default():
+    env = _env(None)
+    res = subprocess.run(
+        ["bash", "-c", f'source "{INSTALL_SH}"\nselect_web_port >/dev/null 2>&1; echo "$WEB_PORT"'],
+        capture_output=True,
+        text=True,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == "7000", res.stdout
+    print("OK: unattended install keeps port 7000")
+
+
+def test_prompt_accepts_custom_port():
+    code, out = run_bash_on_tty('select_web_port; echo "PORT=$WEB_PORT"', "8443\n")
+    assert code == 0, out
+    assert "PORT=8443" in out, out
+    print("OK: answering the prompt sets the port")
+
+
+def test_prompt_empty_answer_keeps_default():
+    code, out = run_bash_on_tty('select_web_port; echo "PORT=$WEB_PORT"', "\n")
+    assert code == 0, out
+    assert "PORT=7000" in out, out
+    print("OK: pressing Enter keeps 7000")
+
+
+def test_prompt_reasks_after_invalid_answer():
+    code, out = run_bash_on_tty('select_web_port; echo "PORT=$WEB_PORT"', "70000\nabc\n9090\n")
+    assert code == 0, out
+    assert "PORT=9090" in out, out
+    assert "not a valid port" in out, out
+    print("OK: invalid answers are re-asked, not accepted")
+
+
+def test_prompt_rejects_a_busy_port():
+    if not (shutil.which("ss") or shutil.which("netstat")):
+        print("SKIP: no ss/netstat to detect busy ports")
+        return
+    with socket.socket() as srv:
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        busy = srv.getsockname()[1]
+        code, out = run_bash_on_tty('select_web_port; echo "PORT=$WEB_PORT"', f"{busy}\n9091\n")
+    assert code == 0, out
+    assert "PORT=9091" in out, out
+    assert "already used" in out, out
+    print("OK: a busy port is refused")
+
+
+def test_service_unit_and_firewall_use_the_chosen_port():
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    assert "Environment=PG_MIGRATOR_PORT=${WEB_PORT}" in text
+    assert "--port ${WEB_PORT}" in text
+    assert 'ufw allow "${WEB_PORT}/tcp"' in text
+    assert not re.search(r"--port 7000", text)
+    print("OK: unit file, firewall and banner follow WEB_PORT")
+
+
+def test_app_config_reads_the_port_from_the_environment():
+    with tempfile.TemporaryDirectory() as tmp:
+        snippet = "import app.config as c; print(c.WEB_PORT)"
+        for value, expected in (("8443", "8443"), ("", "7000"), ("abc", "7000"), ("0", "7000")):
+            env = {**os.environ, "PG_MIGRATOR_HOME": tmp, "PG_MIGRATOR_PORT": value}
+            res = subprocess.run(
+                [sys.executable, "-c", snippet],
+                capture_output=True, text=True, cwd=str(ROOT), env=env,
+            )
+            assert res.returncode == 0, res.stderr
+            assert res.stdout.strip() == expected, f"{value!r} -> {res.stdout!r}"
+    print("OK: app.config.WEB_PORT follows PG_MIGRATOR_PORT")
+
+
+if __name__ == "__main__":
+    test_valid_port_accepts_and_rejects()
+    test_detect_installed_port_reads_existing_unit()
+    test_env_var_selects_port_without_prompting()
+    test_invalid_env_var_aborts_install()
+    test_no_terminal_falls_back_to_default()
+    test_prompt_accepts_custom_port()
+    test_prompt_empty_answer_keeps_default()
+    test_prompt_reasks_after_invalid_answer()
+    test_prompt_rejects_a_busy_port()
+    test_service_unit_and_firewall_use_the_chosen_port()
+    test_app_config_reads_the_port_from_the_environment()
+    print("\nAll install port tests passed.")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## چه چیزی عوض شد

اسکریپت نصب حالا یک منوی کامل است. با اجرا، صفحه پاک می‌شود و بالای گزینه‌ها وضعیت سرور نمایش داده می‌شود. همه متن‌ها انگلیسی است.

```
  ╔══════════════════════════════════════════════════════════╗
  ║   PGClockMG  ·  PasarGuard restore & migration wizard    ║
  ╚══════════════════════════════════════════════════════════╝

   Installer 3.2.0   ·   Server 203.0.113.10

  SYSTEM STATUS
  ────────────────────────────────────────────────────────────
   [ OK ]  PasarGuard        installed · v1.4.2 · running
   [ OK ]  Panel database    timescaledb
   [ OK ]  Docker            running
   [ OK ]  Wizard            v3.2.0 · http://203.0.113.10:8443
   [WARN]  Redirect server   stopped · hiddify · port 443, 2083

  MENU
  ────────────────────────────────────────────────────────────
   1)  Install / update the web panel
   2)  Uninstall the web panel
   3)  Redirect server  (3x-ui / Hiddify only)
   4)  Exit
```

اگر پاسارگارد نصب نباشد، ردیف آن قرمز (`[MISS]`) می‌شود و زیر وضعیت این پیام می‌آید:
«PasarGuard was not found on this server. This wizard only restores and migrates data INTO an existing panel. Install PasarGuard first: …»

## گزینه‌ها

- **۱ · Install / update** — پورت را می‌پرسد (Enter = پورت فعلی یا `7000`)، بعد از جواب دادن کل نصب خودکار انجام می‌شود و در آخر آدرس و پورت ورود چاپ می‌شود.
- **۲ · Uninstall** — سرویس و `/opt/pg-migrator` را پاک می‌کند، قبلش می‌پرسد بکاپ‌ها را نگه دارد و قانون فایروال پورت را هم برمی‌دارد. پاسارگارد، دیتابیس‌ها و ریدایرکت سرور دست‌نخورده می‌مانند.
- **۳ · Redirect server** — وضعیت (پنل، پورت‌ها، TLS، مقصد ریدایرکت، health check) و چهار عمل: Restart، **Force restart**، Show recent logs، Stop and disable.
- **۴ · Exit**

## حل مشکل «کاربر سرور قبلی را خاموش نکرده»

`pg-redirect` باید روی همان پورت پنل قبلی بایند شود؛ اگر 3x-ui یا Hiddify هنوز بالا باشد پورت اشغال است و سرویس بالا نمی‌آید. گزینه Force restart:

1. سرویس `pg-redirect` را متوقف می‌کند تا systemd وسط کار دوباره بالایش نیاورد.
2. `x-ui` / `redirect-server` و در صورت نیاز (پنل hiddify یا پورت ۴۴۳) کل وب‌استک هیدیفای (panel/nginx/haproxy/gateway/caddy) را می‌خواباند.
3. کانتینرهای داکری که آن پورت‌ها را publish کرده‌اند stop می‌کند.
4. باقی‌مانده‌ها را با `fuser`، `lsof` و در نهایت PIDهای `ss -lntp` می‌کشد (سرورهای مینیمال معمولاً psmisc/lsof ندارند ولی ss دارند).
5. سرویس را enable و restart می‌کند و با `/healthz` تایید می‌گیرد؛ در صورت شکست، لاگ و اینکه چه پروسه‌ای پورت را گرفته نشان می‌دهد.

قبل از اجرا دقیقاً می‌گوید چه چیزهایی متوقف می‌شوند و تایید می‌گیرد، و تصریح می‌کند که پاسارگارد و داده‌های مهاجرت‌شده دست نمی‌خورند.

## بدون تغییر ماندن مسیر مهاجرت/ریستور

هیچ فایلی در `app/services/**` (مهاجرت، ریستور، redirect_ops) تغییر نکرده. تنها تغییر پایتون در این PR همان `app/config.py` مرحله قبل است (خواندن پورت از env) به‌علاوه بامپ نسخه. مراحل نصب (`install_packages`، `copy_app_files`، `setup_python_env`، …) عیناً همان توابع قبلی‌اند و فقط از داخل منو صدا زده می‌شوند.

## نکته فنی مهم

اجرای اکشن‌ها با `action || true` انجام نمی‌شود: bash در دستوری که وضعیتش تست می‌شود errexit را خاموش می‌کند و این حالت به توابع و ساب‌شل‌های داخلش هم ارث می‌رسد — یعنی یک مرحله‌ی خطادار نصب نادیده گرفته می‌شد و مراحل بعدی ادامه پیدا می‌کردند. برای همین `run_action` اضافه شد که آپشن را دور یک فراخوانی ساده خاموش/روشن می‌کند و نتیجه را در `LAST_ACTION_RC` می‌گذارد. یک تست مخصوص همین رفتار هست.

## غیرتعاملی (سازگار با قبل)

`curl | bash` بدون ترمینال مثل قبل مستقیم نصب می‌کند. علاوه بر آن:

```bash
sudo PG_MIGRATOR_ACTION=install PG_MIGRATOR_PORT=8443 bash -c "$(curl -fsSL ...)"
sudo PG_MIGRATOR_ACTION=redirect-restart bash -c "$(curl -fsSL ...)"
sudo PG_MIGRATOR_ACTION=uninstall PG_MIGRATOR_YES=1 bash -c "$(curl -fsSL ...)"
```

## تست

`tests/test_install_menu.py` با ۲۴ تست اضافه شد (کنار ۱۱ تست پورت). تست‌ها install.sh را با `PG_MIGRATOR_INSTALL_LIB=1` سورس می‌کنند و همه مسیرها را به یک sandbox موقت می‌برند، پس `/opt/pasarguard`، `/etc/pg-redirect` و یونیت‌های واقعی هرگز لمس نمی‌شوند. منو روی pty شبیه‌سازی می‌شود.

پوشش: تشخیص نوع دیتابیس (۵ ترکیب env/compose)، نسخه پاسارگارد (با تگ، بدون تگ، بدون compose)، رندر وضعیت و پیام نبودن پاسارگارد، فلوی کامل نصب از منو (با استاب `run_install`)، توقف نصب روی اولین مرحله‌ی خطادار، پارس کانفیگ ریدایرکت، منوی ریدایرکت با و بدون کانفیگ، تایید‌گرفتن Force restart، **کشتن یک لیسنر واقعی روی پورت**، health probe، آنینستال (پاک‌سازی + نگه‌داشتن بکاپ + انصراف + سرور تمیز) و dispatch خط فرمان.

کل سوییت: `379 passed, 11 skipped`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01974-6c6d-735d-b1f0-72f477615446?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01974-6c6d-735d-b1f0-72f477615446&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

