### PR TITLE
Sync install.sh SCRIPT_VERSION to v4.2.0

### DIFF
--- a/app/static/js/backup.js
+++ b/app/static/js/backup.js
@@ -897,7 +897,7 @@ function esc(s) {
 async function boot() {
   setBackupLang(lang);
   const st = await api("/api/setup/status");
-  document.getElementById("appVersion").textContent = "v" + (st.version || "4.0.1");
+  document.getElementById("appVersion").textContent = "v" + (st.version || "4.2.0");
   setupMode = !st.password_set;
   window.__setupTokenRequired = !!st.setup_token_required;
   document.getElementById("authConfirmWrap").classList.toggle("hidden", !setupMode);

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="4.1.5"
+readonly SCRIPT_VERSION="4.2.0"
 readonly INSTALL_DIR="${PG_MIGRATOR_INSTALL_DIR:-/opt/pg-migrator}"
 readonly BACKUP_INSTALL_DIR="${PG_BACKUP_INSTALL_DIR:-/opt/pg-backup}"
 readonly SERVICE_NAME="pg-migrator"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `install.sh` `SCRIPT_VERSION` was still `4.1.5` after the v4.2.0 release — installer banner now shows **4.2.0**
- Backup panel JS fallback version aligned to `4.2.0` (was `4.0.1`)

App sources (`APP_VERSION`), HTML cache-busters, and READMEs were already on 4.2.0.

## Test plan
- [x] `tests/test_install_menu.py` (31 tests) pass
- [ ] Confirm installer banner prints `Installer 4.2.0` after install from `main`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04f50-fff3-7900-82d7-f1df60610a7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04f50-fff3-7900-82d7-f1df60610a7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

