### PR TITLE
Fix panel open URL to use DASHBOARD_PATH from .env

### DIFF
--- a/app/services/env_migration.py
+++ b/app/services/env_migration.py
@@ -674,6 +674,9 @@ def extract_env_summary(text: str) -> dict:
     panel_port = read_env_var(text, "UVICORN_PORT") or "8000"
     panel_host = read_env_var(text, "UVICORN_HOST") or "0.0.0.0"
     panel_root_path = (read_env_var(text, "UVICORN_ROOT_PATH") or "").rstrip("/") or "/"
+    from app.services.pg_access import resolve_dashboard_path
+
+    panel_dashboard_path = resolve_dashboard_path(text)
     return {
         "db_type": db_type,
         "db_user": db_user,
@@ -686,30 +689,31 @@ def extract_env_summary(text: str) -> dict:
         "panel_port": panel_port,
         "panel_host": panel_host,
         "panel_root_path": panel_root_path,
+        "panel_dashboard_path": panel_dashboard_path,
         "has_password": bool(db_password),
     }
 
 
 def get_panel_url_from_env(env_text: str | None = None, ip: str | None = None) -> str:
     """Build PasarGuard dashboard URL — domain from .env preferred, else IP."""
-    from app.services.pg_access import build_dashboard_url, get_panel_access_info
+    from app.services.pg_access import build_dashboard_url, get_panel_access_info, resolve_dashboard_path
 
     if ip:
         port = "8000"
-        root_path = ""
+        dashboard_path = "/dashboard/"
         if env_text:
             port = read_env_var(env_text, "UVICORN_PORT") or "8000"
-            root_path = (read_env_var(env_text, "UVICORN_ROOT_PATH") or "").rstrip("/")
-        return build_dashboard_url(ip, port, https=True, root_path=root_path)
+            dashboard_path = resolve_dashboard_path(env_text)
+        return build_dashboard_url(ip, port, https=True, dashboard_path=dashboard_path)
 
     access = get_panel_access_info()
     if access.get("login_url"):
         return access["login_url"]
 
     port = (read_env_var(env_text, "UVICORN_PORT") if env_text else None) or "8000"
-    root_path = (read_env_var(env_text, "UVICORN_ROOT_PATH") or "").rstrip("/") if env_text else ""
+    dashboard_path = resolve_dashboard_path(env_text) if env_text else "/dashboard/"
     host = access.get("domain") or access.get("ip") or "127.0.0.1"
-    return build_dashboard_url(host, port, https=True, root_path=root_path)
+    return build_dashboard_url(host, port, https=True, dashboard_path=dashboard_path)
 
 
 def transform_marzban_env(
@@ -1135,8 +1139,8 @@ def finalize_pasarguard_env_after_restore(
         ):
             text = _unset_env_var(text, key)
 
-    # Never overwrite backup UVICORN_PORT/HOST — only fill if missing
-    for key in ("UVICORN_PORT", "UVICORN_HOST", "UVICORN_ROOT_PATH", "ALLOWED_ORIGINS"):
+    # Never overwrite backup UVICORN_PORT/HOST/DASHBOARD_PATH — only fill if missing
+    for key in ("UVICORN_PORT", "UVICORN_HOST", "UVICORN_ROOT_PATH", "DASHBOARD_PATH", "ALLOWED_ORIGINS"):
         if read_env_var(text, key):
             continue
         val = read_env_var(install_env_snapshot, key)
@@ -1247,6 +1251,7 @@ MIGRATE_ENV_KEYS = {
     "UVICORN_HOST",
     "UVICORN_PORT",
     "UVICORN_ROOT_PATH",
+    "DASHBOARD_PATH",
     "XRAY_EXECUTABLE_PATH",
     "XRAY_JSON",
     "SUDO_USERNAME",

--- a/app/services/migrators/hiddify.py
+++ b/app/services/migrators/hiddify.py
@@ -505,6 +505,12 @@ class HiddifyMigrator(BaseMigrator):
         return False, detail
 
     def _get_panel_url(self) -> str:
-        from app.services.pg_access import get_panel_access_info
+        from app.services.pg_access import get_panel_access_info, build_dashboard_url, resolve_dashboard_path
+        from app.config import PASARGUARD_ENV
 
-        return get_panel_access_info().get("login_url") or "https://127.0.0.1:8000/dashboard/"
+        access = get_panel_access_info()
+        if access.get("login_url"):
+            return access["login_url"]
+        env_text = PASARGUARD_ENV.read_text(encoding="utf-8", errors="ignore") if PASARGUARD_ENV.exists() else ""
+        dash = resolve_dashboard_path(env_text) if env_text else "/dashboard/"
+        return build_dashboard_url("127.0.0.1", access.get("port") or "8000", https=True, dashboard_path=dash)

--- a/app/services/migrators/marzban.py
+++ b/app/services/migrators/marzban.py
@@ -813,11 +813,16 @@ class MarzbanMigrator(BaseMigrator):
         access = get_panel_access_info()
         env_text = PASARGUARD_ENV.read_text(encoding="utf-8", errors="ignore") if PASARGUARD_ENV.exists() else None
         port = read_env_var(env_text, "UVICORN_PORT") if env_text else None
+        from app.services.pg_access import resolve_dashboard_path
+
+        dash = resolve_dashboard_path(env_text) if env_text else (access.get("dashboard_path") or "/dashboard/")
         root = (read_env_var(env_text, "UVICORN_ROOT_PATH") or "").rstrip("/") if env_text else ""
         out = {
             "panel_url": access.get("login_url") or get_panel_url_from_env(env_text),
             "panel_port": port or access.get("port") or "8000",
             "panel_root_path": root or access.get("root_path") or "/",
+            "panel_dashboard_path": dash,
+            "dashboard_path": dash,
             "login_url": access.get("login_url"),
             "root_path": access.get("root_path"),
             "subscription_mode": "native",

--- a/app/services/migrators/pasarguard_db.py
+++ b/app/services/migrators/pasarguard_db.py
@@ -152,6 +152,12 @@ class PasarguardDbMigrator(BaseMigrator):
         self.job.log(f".env finalized for {target_db}")
 
     def _get_panel_url(self) -> str:
-        from app.services.pg_access import get_panel_access_info
+        from app.services.pg_access import get_panel_access_info, build_dashboard_url, resolve_dashboard_path
+        from app.config import PASARGUARD_ENV
 
-        return get_panel_access_info().get("login_url") or "https://127.0.0.1:8000/dashboard/"
+        access = get_panel_access_info()
+        if access.get("login_url"):
+            return access["login_url"]
+        env_text = PASARGUARD_ENV.read_text(encoding="utf-8", errors="ignore") if PASARGUARD_ENV.exists() else ""
+        dash = resolve_dashboard_path(env_text) if env_text else "/dashboard/"
+        return build_dashboard_url("127.0.0.1", access.get("port") or "8000", https=True, dashboard_path=dash)

--- a/app/services/migrators/remnawave.py
+++ b/app/services/migrators/remnawave.py
@@ -99,6 +99,12 @@ class RemnawaveMigrator(BaseMigrator):
         )
 
     def _get_panel_url(self) -> str:
-        from app.services.pg_access import get_panel_access_info
+        from app.services.pg_access import get_panel_access_info, build_dashboard_url, resolve_dashboard_path
+        from app.config import PASARGUARD_ENV
 
-        return get_panel_access_info().get("login_url") or "https://127.0.0.1:8000/dashboard/"
+        access = get_panel_access_info()
+        if access.get("login_url"):
+            return access["login_url"]
+        env_text = PASARGUARD_ENV.read_text(encoding="utf-8", errors="ignore") if PASARGUARD_ENV.exists() else ""
+        dash = resolve_dashboard_path(env_text) if env_text else "/dashboard/"
+        return build_dashboard_url("127.0.0.1", access.get("port") or "8000", https=True, dashboard_path=dash)

--- a/app/services/migrators/xui.py
+++ b/app/services/migrators/xui.py
@@ -2915,9 +2915,13 @@ class XuiMigrator(BaseMigrator):
         return resolved
 
     def _get_panel_url(self) -> str:
-        from app.services.pg_access import get_panel_access_info
+        from app.services.pg_access import get_panel_access_info, build_dashboard_url, resolve_dashboard_path
+        from app.config import PASARGUARD_ENV
 
-        return (
-            get_panel_access_info().get("login_url")
-            or f"https://{detect_public_ip()}:8000/dashboard/"
-        )
+        access = get_panel_access_info()
+        if access.get("login_url"):
+            return access["login_url"]
+        env_text = PASARGUARD_ENV.read_text(encoding="utf-8", errors="ignore") if PASARGUARD_ENV.exists() else ""
+        dash = resolve_dashboard_path(env_text) if env_text else "/dashboard/"
+        port = access.get("port") or "8000"
+        return build_dashboard_url(detect_public_ip(), port, https=True, dashboard_path=dash)

--- a/app/services/pg_access.py
+++ b/app/services/pg_access.py
@@ -106,14 +106,58 @@ def resolve_pasarguard_public_base(env_text: str | None = None) -> str:
     return f"{scheme}://{host}:{port}"
 
 
-def build_dashboard_url(host: str, port: str | int = "8000", *, https: bool = True, root_path: str = "") -> str:
-    """Canonical panel login URL: https://host:8000/dashboard/"""
+def normalize_dashboard_path(path: str | None, *, default: str = "/dashboard/") -> str:
+    """Normalize DASHBOARD_PATH to a leading+trailing-slash form."""
+    raw = (path or "").strip().strip('"').strip("'")
+    if not raw:
+        return default
+    if not raw.startswith("/"):
+        raw = "/" + raw
+    if not raw.endswith("/"):
+        raw = raw + "/"
+    # Collapse duplicate slashes without touching the leading one
+    while "//" in raw:
+        raw = raw.replace("//", "/")
+    return raw or default
+
+
+def resolve_dashboard_path(env_text: str | None = None) -> str:
+    """Panel UI path from .env: DASHBOARD_PATH (PasarGuard/Marzban), else legacy ROOT_PATH.
+
+    PasarGuard and Marzban both use DASHBOARD_PATH (default ``/dashboard/``).
+    Older setups sometimes set UVICORN_ROOT_PATH as a prefix before /dashboard/.
+    """
+    text = env_text if env_text is not None else ""
+    dash = read_env_var(text, "DASHBOARD_PATH") if text else None
+    if dash and str(dash).strip():
+        return normalize_dashboard_path(str(dash))
+    root = (read_env_var(text, "UVICORN_ROOT_PATH") or "").strip().rstrip("/") if text else ""
+    if root:
+        return normalize_dashboard_path(f"{root}/dashboard/")
+    return "/dashboard/"
+
+
+def build_dashboard_url(
+    host: str,
+    port: str | int = "8000",
+    *,
+    https: bool = True,
+    root_path: str = "",
+    dashboard_path: str | None = None,
+) -> str:
+    """Canonical panel login URL from host/port + DASHBOARD_PATH.
+
+    Prefer ``dashboard_path`` (from DASHBOARD_PATH in .env). Legacy callers may
+    still pass ``root_path`` (UVICORN_ROOT_PATH) which prefixes ``/dashboard/``.
+    """
     host = (host or "").strip()
     port = str(port or "8000").strip() or "8000"
-    rp = (root_path or "").rstrip("/")
-    path = f"{rp}/dashboard/".replace("//", "/")
-    if not path.startswith("/"):
-        path = "/" + path
+    if dashboard_path is not None and str(dashboard_path).strip():
+        path = normalize_dashboard_path(dashboard_path)
+    elif root_path and str(root_path).strip() and str(root_path).strip() != "/":
+        path = normalize_dashboard_path(f"{str(root_path).rstrip('/')}/dashboard/")
+    else:
+        path = "/dashboard/"
     scheme = "https" if https else "http"
     return f"{scheme}://{host}:{port}{path}"
 
@@ -125,6 +169,7 @@ def get_panel_access_info(prefer_host: str | None = None) -> dict:
     detected_ip = _server_ip()
     port = (read_env_var(env_text, "UVICORN_PORT") if env_text else None) or "8000"
     root_path = (read_env_var(env_text, "UVICORN_ROOT_PATH") or "").rstrip("/")
+    dashboard_path = resolve_dashboard_path(env_text) if env_text else "/dashboard/"
     ssl = _has_ssl(env_text) if env_text else False
     domain = _guess_domain(env_text) if env_text else None
 
@@ -140,9 +185,9 @@ def get_panel_access_info(prefer_host: str | None = None) -> dict:
         ip = detected_ip
         host = domain or ip
 
-    public_https = build_dashboard_url(host, port, https=True, root_path=root_path)
-    public_http = build_dashboard_url(host, port, https=False, root_path=root_path)
-    localhost_url = build_dashboard_url("127.0.0.1", port, https=False, root_path=root_path)
+    public_https = build_dashboard_url(host, port, https=True, dashboard_path=dashboard_path)
+    public_http = build_dashboard_url(host, port, https=False, dashboard_path=dashboard_path)
+    localhost_url = build_dashboard_url("127.0.0.1", port, https=False, dashboard_path=dashboard_path)
     ssh_tunnel = f"ssh -L {port}:localhost:{port} user@{ip}"
     owner_cmd = "pasarguard cli generate-temp-key"
     env_path = "/opt/pasarguard/.env"
@@ -167,7 +212,7 @@ def get_panel_access_info(prefer_host: str | None = None) -> dict:
                 "items": [
                     {"text": "Dashboard URL:", "copy": public_https},
                     {"text": "Config file:", "copy": env_path},
-                    {"text": "Change port/path with UVICORN_PORT and UVICORN_ROOT_PATH in .env", "copy": None},
+                    {"text": "Change port/path with UVICORN_PORT and DASHBOARD_PATH in .env", "copy": None},
                 ],
             },
             {
@@ -200,7 +245,7 @@ def get_panel_access_info(prefer_host: str | None = None) -> dict:
                 "items": [
                     {"text": "لینک داشبورد:", "copy": public_https},
                     {"text": "مسیر فایل تنظیمات:", "copy": env_path},
-                    {"text": "پورت و path را با UVICORN_PORT و UVICORN_ROOT_PATH در .env عوض کنید.", "copy": None},
+                    {"text": "پورت و path را با UVICORN_PORT و DASHBOARD_PATH در .env عوض کنید.", "copy": None},
                 ],
             },
             {
@@ -233,7 +278,7 @@ def get_panel_access_info(prefer_host: str | None = None) -> dict:
                 "items": [
                     {"text": "URL дашборда:", "copy": public_https},
                     {"text": "Файл настроек:", "copy": env_path},
-                    {"text": "Порт/path: UVICORN_PORT и UVICORN_ROOT_PATH в .env", "copy": None},
+                    {"text": "Порт/path: UVICORN_PORT и DASHBOARD_PATH в .env", "copy": None},
                 ],
             },
             {
@@ -277,6 +322,7 @@ def get_panel_access_info(prefer_host: str | None = None) -> dict:
         "ip": ip,
         "port": port,
         "root_path": root_path or "/",
+        "dashboard_path": dashboard_path,
         "panel_url": login_url,
         "public_url": public_https,
         "public_http_url": public_http,

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -3869,7 +3869,7 @@ async def _merge_env_after_restore(
 
     text = backup_env
     # Only fill panel listen settings if backup omitted them
-    for key in ("UVICORN_PORT", "UVICORN_HOST", "UVICORN_ROOT_PATH", "ALLOWED_ORIGINS"):
+    for key in ("UVICORN_PORT", "UVICORN_HOST", "UVICORN_ROOT_PATH", "DASHBOARD_PATH", "ALLOWED_ORIGINS"):
         if read_env_var(text, key):
             continue
         cur = read_env_var(current_env, key)

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1416,18 +1416,31 @@ function showSuccess(result) {
   document.getElementById('resultError').classList.add('hidden');
   document.querySelector('#resultSuccess h2').textContent = t('step6.success');
 
+  const dashRaw = result?.panel_dashboard_path
+    || result?.dashboard_path
+    || state.pasarguardEnvSummary?.panel_dashboard_path
+    || state.systemCheck?.pasarguard_env?.panel_dashboard_path
+    || state.panelAccess?.dashboard_path
+    || '';
   const rootRaw = result?.panel_root_path
     || state.pasarguardEnvSummary?.panel_root_path
     || state.systemCheck?.pasarguard_env?.panel_root_path
     || '';
-  const root = (rootRaw && rootRaw !== '/' ? String(rootRaw).replace(/\/$/, '') : '');
+  let dash = (dashRaw && String(dashRaw).trim()) || '';
+  if (!dash) {
+    const root = (rootRaw && rootRaw !== '/' ? String(rootRaw).replace(/\/$/, '') : '');
+    dash = root ? `${root}/dashboard/` : '/dashboard/';
+  }
+  if (!dash.startsWith('/')) dash = `/${dash}`;
+  if (!dash.endsWith('/')) dash = `${dash}/`;
+  dash = dash.replace(/\/{2,}/g, '/');
   const port = result?.panel_port || state.pasarguardEnvSummary?.panel_port || state.systemCheck?.pasarguard_env?.panel_port || '8000';
   const accessUrl = (typeof resolveLoginUrl === 'function')
     ? resolveLoginUrl(state.panelAccess || state.systemCheck?.panel_access)
     : (state.panelAccess?.login_url || state.systemCheck?.panel_access?.login_url || '');
   const panelUrl = result?.panel_url
     || accessUrl
-    || `https://${state.serverIp.split(':')[0]}:${port}${root}/dashboard/`.replace(/([^:]\/)\/+/g, '$1');
+    || `https://${state.serverIp.split(':')[0]}:${port}${dash}`.replace(/([^:]\/)\/+/g, '$1');
   document.getElementById('panelLink').href = panelUrl;
 
   const mode = result?.subscription_mode || state.selectedPanel?.subscription_mode;

--- a/app/static/js/wizard-flow.js
+++ b/app/static/js/wizard-flow.js
@@ -153,16 +153,21 @@ function renderGuideSections(container, access) {
 
 function resolveLoginUrl(access) {
   const a = access || state.panelAccess || {};
-  // Prefer server-built URL (already includes UVICORN_ROOT_PATH from .env)
+  // Prefer server-built URL (already includes DASHBOARD_PATH from .env)
   const preferred = a.login_url || a.panel_url || a.public_url || a.localhost_url || '';
   if (preferred) return preferred;
   const host = (state.pgDomain || a.domain || state.pgIp || a.host || a.ip || '').trim();
   const port = a.port || '8000';
-  const root = (a.root_path && a.root_path !== '/' ? a.root_path : '') || '';
+  let dash = (a.dashboard_path || a.panel_dashboard_path || '').trim();
+  if (!dash) {
+    const root = (a.root_path && a.root_path !== '/' ? a.root_path : '') || '';
+    dash = root ? `${root}/dashboard/` : '/dashboard/';
+  }
+  if (!dash.startsWith('/')) dash = `/${dash}`;
+  if (!dash.endsWith('/')) dash = `${dash}/`;
+  dash = dash.replace(/\/{2,}/g, '/');
   if (host && host !== '127.0.0.1' && host !== 'localhost') {
-    const path = `${root}/dashboard/`.replace(/\/{2,}/g, '/');
-    const p = path.startsWith('/') ? path : `/${path}`;
-    return `https://${host}:${port}${p}`;
+    return `https://${host}:${port}${dash}`;
   }
   return '';
 }

--- a/tests/test_pg_access_dashboard_path.py
+++ b/tests/test_pg_access_dashboard_path.py
@@ -1,0 +1,73 @@
+"""DASHBOARD_PATH must drive panel login URLs (not a hardcoded /dashboard/)."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from app.services.pg_access import (
+    build_dashboard_url,
+    normalize_dashboard_path,
+    resolve_dashboard_path,
+)
+from app.services.env_migration import get_panel_url_from_env
+
+
+def test_normalize_dashboard_path():
+    assert normalize_dashboard_path(None) == "/dashboard/"
+    assert normalize_dashboard_path("") == "/dashboard/"
+    assert normalize_dashboard_path("secret") == "/secret/"
+    assert normalize_dashboard_path("/panel") == "/panel/"
+    assert normalize_dashboard_path("/panel/") == "/panel/"
+    assert normalize_dashboard_path('"/my-admin/"') == "/my-admin/"
+    print("OK: normalize_dashboard_path")
+
+
+def test_resolve_dashboard_path_prefers_dashboard_path():
+    env = 'DASHBOARD_PATH = "/my-panel/"\nUVICORN_ROOT_PATH = "/ignored/"\n'
+    assert resolve_dashboard_path(env) == "/my-panel/"
+    print("OK: DASHBOARD_PATH wins over ROOT_PATH")
+
+
+def test_resolve_dashboard_path_legacy_root_path():
+    env = 'UVICORN_ROOT_PATH = "/prefix"\n'
+    assert resolve_dashboard_path(env) == "/prefix/dashboard/"
+    print("OK: legacy UVICORN_ROOT_PATH → /prefix/dashboard/")
+
+
+def test_resolve_dashboard_path_default():
+    assert resolve_dashboard_path("") == "/dashboard/"
+    assert resolve_dashboard_path("UVICORN_PORT = 8000\n") == "/dashboard/"
+    print("OK: default /dashboard/")
+
+
+def test_build_dashboard_url_uses_dashboard_path():
+    url = build_dashboard_url("panel.example.com", 8000, https=True, dashboard_path="/admin/")
+    assert url == "https://panel.example.com:8000/admin/"
+    url2 = build_dashboard_url("10.0.0.1", "8000", https=False, dashboard_path="secret")
+    assert url2 == "http://10.0.0.1:8000/secret/"
+    print("OK: build_dashboard_url with DASHBOARD_PATH")
+
+
+def test_build_dashboard_url_legacy_root_path():
+    url = build_dashboard_url("host.example", 8000, root_path="/x")
+    assert url == "https://host.example:8000/x/dashboard/"
+    print("OK: build_dashboard_url legacy root_path")
+
+
+def test_get_panel_url_from_env_reads_dashboard_path():
+    env = 'UVICORN_PORT = 8443\nDASHBOARD_PATH = "/pg/"\n'
+    url = get_panel_url_from_env(env, ip="203.0.113.10")
+    assert url == "https://203.0.113.10:8443/pg/"
+    print("OK: get_panel_url_from_env uses DASHBOARD_PATH")
+
+
+if __name__ == "__main__":
+    test_normalize_dashboard_path()
+    test_resolve_dashboard_path_prefers_dashboard_path()
+    test_resolve_dashboard_path_legacy_root_path()
+    test_resolve_dashboard_path_default()
+    test_build_dashboard_url_uses_dashboard_path()
+    test_build_dashboard_url_legacy_root_path()
+    test_get_panel_url_from_env_reads_dashboard_path()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The success-step «ورود به پنل» link always used `/dashboard/`, ignoring the panel path from the transferred `.env`.

PasarGuard and Marzban both use **`DASHBOARD_PATH`** (default `/dashboard/`). This PR reads that value for login URLs across restore, migrate, and UI.

## Changes
- `build_dashboard_url` / `get_panel_access_info` use `DASHBOARD_PATH` (legacy `UVICORN_ROOT_PATH` → `{root}/dashboard/` fallback)
- Restore / finalize / Marzban migrate env merge preserve `DASHBOARD_PATH`
- Wizard success + restore success JS fallbacks use `dashboard_path`
- All migrator `_get_panel_url` helpers aligned
- Unit tests for path resolution

## Test plan
- [x] `tests/test_pg_access_dashboard_path.py`
- [x] env migration / finalize tests
- [ ] Manual: restore/migrate with `DASHBOARD_PATH=/secret/` → open-panel URL ends with `/secret/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04f50-fff3-7900-82d7-f1df60610a7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04f50-fff3-7900-82d7-f1df60610a7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

