### PR TITLE
هماهنگ‌سازی استایل باکس وضعیت PasarGuard با بقیه داشبورد

### DIFF
--- a/app/static/backup.html
+++ b/app/static/backup.html
@@ -143,9 +143,9 @@
         <div class="backup-dash-stack">
           <div class="backup-icon-grid" id="dashHealthGrid"></div>
 
-          <div id="dashPgCard" class="success-card backup-section-card backup-pg-card">
+          <div id="dashPgCard" class="info-box backup-section-card backup-pg-card backup-status-card">
             <div class="backup-section-head">
-              <span class="choice-icon icon-tone-blue" aria-hidden="true">
+              <span class="choice-icon icon-tone-blue" id="dashPgIcon" aria-hidden="true">
                 <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M12 3l8 4v6c0 5-3.5 8.5-8 10-4.5-1.5-8-5-8-10V7l8-4z"/></svg>
               </span>
               <div class="backup-section-head-body">

--- a/app/static/css/backup.css
+++ b/app/static/css/backup.css
@@ -1024,13 +1024,19 @@ html[dir="rtl"] .backup-app .specs-item .specs-value[dir="ltr"] {
   margin-top: 12px;
 }
 
-/* PasarGuard status card: icon tones + start-aligned title (RTL = right) */
-#dashPgCard.backup-pg-card,
-#dashPgCard.backup-pg-card.success-card,
-#dashPgCard.backup-pg-card.warning-card {
+/* PasarGuard status card — same neutral info-box look as other dash cards */
+#dashPgCard.backup-pg-card {
   text-align: start !important;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
+  border-color: var(--border-soft);
+  background: var(--bg-card);
+  color: var(--text);
+  justify-content: flex-start;
+}
+
+#dashPgCard .backup-pg-specs {
+  margin-top: 0;
 }
 
 #dashPgCard .backup-section-head {

--- a/app/static/js/backup.js
+++ b/app/static/js/backup.js
@@ -1031,9 +1031,13 @@ async function refreshDashboard() {
   const sched = data.schedule || {};
   const installed = data.pasarguard_installed;
 
-  document.getElementById("dashPgCard").className = installed
-    ? "success-card backup-section-card backup-pg-card"
-    : "warning-card backup-section-card backup-pg-card";
+  const pgCard = document.getElementById("dashPgCard");
+  pgCard.className = "info-box backup-section-card backup-pg-card backup-status-card";
+  pgCard.classList.toggle("is-detailed", true);
+  const pgIcon = document.getElementById("dashPgIcon");
+  if (pgIcon) {
+    pgIcon.className = installed ? "choice-icon icon-tone-blue" : "choice-icon icon-tone-yellow";
+  }
   document.getElementById("dashPgSub").textContent = installed ? t("dashPgSubOk") : t("dashPgSubMissing");
 
   const specs = document.getElementById("dashPgSpecs");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## تغییر
باکس «وضعیت PasarGuard» دیگر سبز (`success-card`) / نارنجی (`warning-card`) نیست.

همان سطح خنثی `info-box` + `backup-status-card` مثل باکس‌های «آخرین بکاپ» و «ارسال» استفاده می‌شود (پس‌زمینه و بوردر یکسان). وضعیت نصب فقط از متن، آیکون و specs مشخص می‌ماند.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04f50-fff3-7900-82d7-f1df60610a7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04f50-fff3-7900-82d7-f1df60610a7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

