### PR TITLE
اسکرول به بالا هنگام نمایش پیام موفق/خطا

### DIFF
--- a/app/static/backup.html
+++ b/app/static/backup.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG Backup</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=4.3.2">
-  <link rel="stylesheet" href="/static/css/backup.css?v=4.3.2">
+  <link rel="stylesheet" href="/static/css/style.css?v=4.3.3">
+  <link rel="stylesheet" href="/static/css/backup.css?v=4.3.3">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Vazirmatn:wght@400;500;600;700&display=swap" media="print" onload="this.media='all'">
@@ -35,7 +35,7 @@
         </div>
         <div class="header-titles">
           <h1>PGClockMG Backup</h1>
-          <p class="header-version" id="appVersion">v4.3.2</p>
+          <p class="header-version" id="appVersion">v4.3.3</p>
         </div>
       </div>
       <div class="header-meta">
@@ -556,6 +556,6 @@
     </div>
   </div>
 
-  <script src="/static/js/backup.js?v=4.3.2"></script>
+  <script src="/static/js/backup.js?v=4.3.3"></script>
 </body>
 </html>

--- a/app/static/css/backup.css
+++ b/app/static/css/backup.css
@@ -607,6 +607,7 @@
   margin: 0 0 18px;
   padding: 0;
   pointer-events: none;
+  scroll-margin-top: 12px;
 }
 
 .backup-toast-host:empty {

--- a/app/static/js/backup.js
+++ b/app/static/js/backup.js
@@ -155,6 +155,7 @@ const I18N = {
     lblNewPassConfirm: "تکرار رمز جدید",
     btnSaveSettings: "ذخیره تنظیمات",
     saved: "ذخیره شد",
+    saveFail: "ذخیره نشد",
     streamH2: "ارسال استریم به ویزارد",
     streamDesc: "فایل بکاپ روی همین سرور می‌ماند؛ فقط یک کپی به ویزارد مقصد فرستاده می‌شود. اول مقصد را در حالت دریافت بگذارید، بعد از اینجا ارسال کنید.",
     streamStep1: "روی سرور مقصد: ویزارد → ریستور → آماده‌سازی دریافت استریم",
@@ -348,6 +349,7 @@ const I18N = {
     lblNewPassConfirm: "Confirm new password",
     btnSaveSettings: "Save settings",
     saved: "Saved",
+    saveFail: "Save failed",
     streamH2: "Stream to wizard",
     streamDesc: "The zip stays on this server; only a copy is sent to the destination wizard. Put the destination in receive mode first, then send from here.",
     streamStep1: "On destination: Wizard → Restore → Ready to receive stream",
@@ -541,6 +543,7 @@ const I18N = {
     lblNewPassConfirm: "Повтор нового пароля",
     btnSaveSettings: "Сохранить настройки",
     saved: "Сохранено",
+    saveFail: "Не сохранено",
     streamH2: "Стрим в мастер",
     streamDesc: "ZIP остаётся на этом сервере; на мастер назначения уходит только копия. Сначала включите приём на назначении, потом отправляйте отсюда.",
     streamStep1: "На назначении: Мастер → Restore → Готов принимать стрим",
@@ -1732,7 +1735,7 @@ async function saveSettings(opts = {}) {
   if (!quiet) showToast(t("saved"), "success");
   refreshTelegramStatusTag().catch(() => {});
   } catch (e) {
-    if (!quiet) showToast((t("saved") || "Save") + ": " + (e.message || e), "error");
+    if (!quiet) showToast(t("saveFail") + ": " + (e.message || e), "error");
     throw e;
   }
 }

--- a/app/static/js/backup.js
+++ b/app/static/js/backup.js
@@ -641,6 +641,21 @@ function showToast(message, type = "success", opts = {}) {
   if (ttl > 0) setTimeout(remove, ttl);
   // Keep sticky host from stacking forever
   while (host.children.length > 4) host.lastElementChild?.remove();
+  // Toasts sit at the top of main — scroll there so Save / ops aren't missed.
+  if (opts.scroll !== false) {
+    requestAnimationFrame(() => {
+      try {
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      } catch (_) {
+        window.scrollTo(0, 0);
+      }
+      try {
+        host.scrollIntoView({ behavior: "smooth", block: "start" });
+      } catch (_) {
+        host.scrollIntoView(true);
+      }
+    });
+  }
 }
 
 function showBackupModal({ title, body, okText, cancelText, danger = false, showCancel = false }) {
@@ -1651,6 +1666,7 @@ async function refreshTelegramStatusTag() {
 
 async function saveSettings(opts = {}) {
   const quiet = !!opts.quiet;
+  try {
   const tokenVal = document.getElementById("tgToken").value.trim();
   const adminId = document.getElementById("tgChat").value.trim();
   const extraChat = document.getElementById("tgChat2").value.trim();
@@ -1715,6 +1731,10 @@ async function saveSettings(opts = {}) {
   }
   if (!quiet) showToast(t("saved"), "success");
   refreshTelegramStatusTag().catch(() => {});
+  } catch (e) {
+    if (!quiet) showToast((t("saved") || "Save") + ": " + (e.message || e), "error");
+    throw e;
+  }
 }
 
 async function testTelegram() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## تغییر
با هر toast (ذخیره موفق/ناموفق، تست تلگرام، بکاپ، …) صفحه به **بالا** اسکرول می‌شود تا باکس پیام دیده شود.

همچنین خطای ذخیره تنظیمات دیگر بی‌صدا نیست و toast خطا نشان می‌دهد.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04f50-fff3-7900-82d7-f1df60610a7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04f50-fff3-7900-82d7-f1df60610a7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

