### PR TITLE
release: v4.3.10

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> 🚀 **`v4.3.9`** — Robust Timescale restoring=on clear (catalog mismatch / multi-DB)
+> 🚀 **`v4.3.10`** — Timescale restore survives full disk / empty compose
 > ⚠️ Always take a full backup before restore or migration.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> 🚀 **`v4.3.9`** — پاک‌سازی مقاوم restoring=on حتی با catalog mismatch
+> 🚀 **`v4.3.10`** — ریستور Timescale بدون گیر کردن روی دیسک پر / compose خالی
 > ⚠️ قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> 🚀 **`v4.3.9`** — Надёжная очистка Timescale restoring=on (catalog mismatch / multi-DB)
+> 🚀 **`v4.3.10`** — Restore Timescale устойчив к ENOSPC / пустому compose
 > ⚠️ Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">

--- a/app/backup_main.py
+++ b/app/backup_main.py
@@ -43,7 +43,7 @@ from app.services.backup_telegram import (
 )
 from app.services.prerequisites import get_system_status, is_pasarguard_installed
 
-APP_VERSION = "4.3.9"
+APP_VERSION = "4.3.10"
 
 
 def _dashboard_update_info() -> dict:

--- a/app/main.py
+++ b/app/main.py
@@ -36,7 +36,7 @@ from app.services.self_uninstall import uninstall_preview, schedule_self_uninsta
 from app.services.auth import COOKIE_NAME, COOKIE_MAX_AGE, ensure_token, token_matches
 from app.config import WEB_PORT
 
-APP_VERSION = "4.3.9"
+APP_VERSION = "4.3.10"
 
 
 @asynccontextmanager

--- a/app/static/backup.html
+++ b/app/static/backup.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG Backup</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=4.3.9">
-  <link rel="stylesheet" href="/static/css/backup.css?v=4.3.9">
+  <link rel="stylesheet" href="/static/css/style.css?v=4.3.10">
+  <link rel="stylesheet" href="/static/css/backup.css?v=4.3.10">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Vazirmatn:wght@400;500;600;700&display=swap" media="print" onload="this.media='all'">
@@ -35,7 +35,7 @@
         </div>
         <div class="header-titles">
           <h1>PGClockMG Backup</h1>
-          <p class="header-version" id="appVersion">v4.3.9</p>
+          <p class="header-version" id="appVersion">v4.3.10</p>
         </div>
       </div>
       <div class="header-meta">
@@ -564,6 +564,6 @@
     </div>
   </div>
 
-  <script src="/static/js/backup.js?v=4.3.9"></script>
+  <script src="/static/js/backup.js?v=4.3.10"></script>
 </body>
 </html>

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="4.3.9"
+readonly SCRIPT_VERSION="4.3.10"
 readonly INSTALL_DIR="${PG_MIGRATOR_INSTALL_DIR:-/opt/pg-migrator}"
 readonly BACKUP_INSTALL_DIR="${PG_BACKUP_INSTALL_DIR:-/opt/pg-backup}"
 readonly SERVICE_NAME="pg-migrator"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release v4.3.10

Version bump for ENOSPC-safe Timescale align + emergency `restoring` clear before image pull (#91).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04f50-fff3-7900-82d7-f1df60610a7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04f50-fff3-7900-82d7-f1df60610a7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

