### PR TITLE
fix multi-worker restore compose merge and health checks (v4.4.2)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> 🚀 **`v4.4.1`** — Fix panel service health check + full NATS/stack orchestration
+> 🚀 **`v4.4.2`** — Dual compose merge + stricter multi-worker health checks
 > ⚠️ Always take a full backup before restore or migration.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> 🚀 **`v4.4.1`** — رفع health check سرویس panel + orchestration کامل NATS/stack
+> 🚀 **`v4.4.2`** — ادغام compose دو فایلی + health check دقیق‌تر multi-worker
 > ⚠️ قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> 🚀 **`v4.4.1`** — Health check для panel + полный NATS/stack orchestration
+> 🚀 **`v4.4.2`** — Merge main+multi compose + строже health check multi-worker
 > ⚠️ Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">

--- a/app/backup_main.py
+++ b/app/backup_main.py
@@ -43,7 +43,7 @@ from app.services.backup_telegram import (
 )
 from app.services.prerequisites import get_system_status, is_pasarguard_installed
 
-APP_VERSION = "4.4.1"
+APP_VERSION = "4.4.2"
 
 
 def _dashboard_update_info() -> dict:

--- a/app/main.py
+++ b/app/main.py
@@ -36,7 +36,7 @@ from app.services.self_uninstall import uninstall_preview, schedule_self_uninsta
 from app.services.auth import COOKIE_NAME, COOKIE_MAX_AGE, ensure_token, token_matches
 from app.config import WEB_PORT
 
-APP_VERSION = "4.4.1"
+APP_VERSION = "4.4.2"
 
 
 @asynccontextmanager

--- a/app/services/multiworker_stack.py
+++ b/app/services/multiworker_stack.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any
 from app.config import PASARGUARD_DIR, PASARGUARD_ENV
 from app.services.env_migration import _set_env_var_simple, read_env_var
 from app.services.pasarguard_ops import (
-    PANEL_BOOT_MARKERS,
     _compose_text,
     compose_file_prefix,
     panel_compose_service,
@@ -68,7 +67,9 @@ def detect_multiworker_stack(env_text: str | None = None) -> dict[str, Any]:
     panel_service = resolve_pasarguard_service()
 
     uses_nats = bool(has_nats and (nats_enabled or workers > 1))
-    orchestrate = bool(uses_nats or satellites)
+    orchestrate = bool(
+        uses_nats or (workers > 1 and (has_nats or satellites))
+    )
 
     return {
         "orchestrate": orchestrate,
@@ -194,8 +195,12 @@ async def ensure_nats_ready(
 
 
 async def wait_for_panel_boot(job: MigrationJob, timeout: int = 120) -> bool:
-    """Wait until panel logs show Uvicorn/startup markers (multi-worker needs longer)."""
+    """Wait until panel logs show startup markers (multi-worker needs stricter markers)."""
+    from app.services.pasarguard_ops import _panel_startup_markers_for_stack
+
     panel = panel_compose_service()
+    info = detect_multiworker_stack()
+    markers = _panel_startup_markers_for_stack(info)
     deadline = max(30, int(timeout))
     for waited in range(0, deadline, 4):
         _ok, logs = await _compose_job(
@@ -209,7 +214,7 @@ async def wait_for_panel_boot(job: MigrationJob, timeout: int = 120) -> bool:
             quiet=True,
         )
         text = logs or ""
-        if any(marker in text for marker in PANEL_BOOT_MARKERS):
+        if any(marker in text for marker in markers):
             job.log("Panel application startup detected")
             return True
         if waited == 0:

--- a/app/services/pasarguard_ops.py
+++ b/app/services/pasarguard_ops.py
@@ -127,8 +127,22 @@ def _compose_text() -> str:
     return "\n".join(parts)
 
 
+def _multi_overlay_services(text: str) -> bool:
+    return bool(
+        re.search(
+            r"^\s*(nats|panel|node-worker|scheduler)\s*:",
+            text,
+            re.MULTILINE,
+        )
+    )
+
+
 def _active_compose_paths() -> list[Path]:
-    """Pick the compose file(s) PasarGuard actually uses (incl. multi-worker layout)."""
+    """Pick the compose file(s) PasarGuard actually uses (incl. multi-worker layout).
+
+    When ``docker-compose.multi.yml`` defines worker-stack services, return both the
+    base file and the overlay so DB services and NATS/panel are in one project.
+    """
     main: Path | None = None
     for name in ("docker-compose.yml", "docker-compose.yaml"):
         p = PASARGUARD_DIR / name
@@ -138,10 +152,9 @@ def _active_compose_paths() -> list[Path]:
     multi = PASARGUARD_DIR / "docker-compose.multi.yml"
     if main is not None and multi.exists():
         try:
-            main_text = main.read_text(encoding="utf-8", errors="ignore")
             multi_text = multi.read_text(encoding="utf-8", errors="ignore")
-            if "nats:" in multi_text and "nats:" not in main_text:
-                return [multi]
+            if _multi_overlay_services(multi_text):
+                return [main, multi]
         except OSError:
             pass
         return [main]
@@ -153,11 +166,16 @@ def _active_compose_paths() -> list[Path]:
 
 
 def compose_file_prefix() -> list[str]:
-    """Extra docker compose args when the active file is not the default name."""
+    """Extra docker compose -f args for the active compose file(s)."""
     paths = _active_compose_paths()
-    if len(paths) == 1 and paths[0].name not in ("docker-compose.yml", "docker-compose.yaml"):
-        return ["-f", str(paths[0])]
-    return []
+    if not paths:
+        return []
+    if len(paths) == 1 and paths[0].name in ("docker-compose.yml", "docker-compose.yaml"):
+        return []
+    args: list[str] = []
+    for p in paths:
+        args.extend(["-f", str(p)])
+    return args
 
 
 def panel_compose_service() -> str:
@@ -204,6 +222,10 @@ def _line_indicates_failure(line: str) -> bool:
     if any(b in line for b in BENIGN_LOG_PATTERNS):
         return False
     if _is_banner_noise(line):
+        return False
+    # Multi-worker Uvicorn prints bare Traceback headers while workers retry;
+    # the following Error/Exception line is the actionable signal.
+    if "Traceback (most recent call last)" in line:
         return False
     return any(p in line for p in FAIL_LOG_PATTERNS)
 
@@ -319,6 +341,17 @@ async def _panel_port_is_listening(migrator) -> bool:
     except OSError:
         migrator.job.log(f"Panel port {port} not accepting connections yet")
         return False
+
+
+def _panel_startup_markers_for_stack(stack: dict | None = None) -> tuple[str, ...]:
+    """Multi-worker needs Application startup complete — Uvicorn bind alone is not enough."""
+    if stack and (stack.get("orchestrate") or (stack.get("uvicorn_workers") or 1) > 1):
+        return ("Application startup complete", "Starting backend")
+    return STARTUP_MARKERS
+
+
+def _logs_show_panel_startup(output: str, stack: dict | None = None) -> bool:
+    return any(marker in (output or "") for marker in _panel_startup_markers_for_stack(stack))
 
 
 def _check_logs_for_failure(output: str) -> str | None:
@@ -1153,7 +1186,7 @@ async def verify_pasarguard_healthy(migrator, max_wait: int = 180) -> None:
             and not last_upgrade_sig
             and not bootstrap_now
         ):
-            has_startup = any(marker in (out or "") for marker in STARTUP_MARKERS)
+            has_startup = _logs_show_panel_startup(out, stack)
             if not has_startup:
                 silent_loop_healed = True
                 await _heal_silent_restart_loop(migrator)
@@ -1235,7 +1268,7 @@ async def verify_pasarguard_healthy(migrator, max_wait: int = 180) -> None:
         not_running_streak = 0
         unknown_streak = 0
         restarting_streak = 0
-        if any(marker in (out or "") for marker in STARTUP_MARKERS):
+        if _logs_show_panel_startup(out, stack):
             stable_ready += 1
             if stable_ready >= 2:
                 if await _panel_port_is_listening(migrator):
@@ -1257,7 +1290,7 @@ async def verify_pasarguard_healthy(migrator, max_wait: int = 180) -> None:
             "PasarGuard startup failed.\n" + _extract_failure_snippet(out)
         )
     last_up = last_upgrade_sig or _last_alembic_upgrade_line(out)
-    if last_up and not any(m in (out or "") for m in STARTUP_MARKERS):
+    if last_up and not _logs_show_panel_startup(out, stack):
         raise RuntimeError(
             "PasarGuard did not finish alembic / reach ready state in time.\n"
             f"Last upgrade still in progress or incomplete: {last_up}\n"
@@ -1338,7 +1371,7 @@ def read_source_alembic_version(
 
 async def docker_compose_up(migrator, services: list[str] | None = None) -> bool:
     cwd = str(PASARGUARD_DIR)
-    cmd = ["docker", "compose", "up", "-d"]
+    cmd = ["docker", "compose", *compose_file_prefix(), "up", "-d"]
     if services:
         cmd.extend(services)
     ok, _ = await migrator._run_cmd(cmd, cwd=cwd, timeout=180)
@@ -1346,7 +1379,10 @@ async def docker_compose_up(migrator, services: list[str] | None = None) -> bool
 
 
 async def wait_pasarguard_ready(migrator, max_wait: int = 90, strict: bool = False) -> bool:
+    from app.services.multiworker_stack import detect_multiworker_stack
+
     cwd = str(PASARGUARD_DIR)
+    stack = detect_multiworker_stack()
     migrator.job.log("Waiting for PasarGuard to become ready...")
 
     for attempt in range(max(1, max_wait // 3)):
@@ -1359,7 +1395,7 @@ async def wait_pasarguard_ready(migrator, max_wait: int = 90, strict: bool = Fal
                 )
             migrator.job.log(f"Detected PasarGuard log error: {hit}")
 
-        if any(marker in (out or "") for marker in STARTUP_MARKERS):
+        if _logs_show_panel_startup(out, stack):
             migrator.job.log("PasarGuard ready")
             return True
 
@@ -1541,11 +1577,46 @@ async def run_alembic_upgrade(migrator) -> bool:
 
 
 def resolve_pasarguard_service() -> str:
-    text = _compose_text()
-    for name in PASARGUARD_SERVICE_CANDIDATES:
-        if re.search(rf"^\s*{re.escape(name)}\s*:", text, re.MULTILINE):
-            return name
-    return "pasarguard"
+    """Resolve panel service; overlay wins when multi-worker is active."""
+    paths = _active_compose_paths()
+    if not paths:
+        return "pasarguard"
+
+    per_file: list[str] = []
+    for path in reversed(paths):
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for name in PASARGUARD_SERVICE_CANDIDATES:
+            if re.search(rf"^\s*{re.escape(name)}\s*:", text, re.MULTILINE):
+                per_file.append(name)
+                break
+
+    if not per_file:
+        return "pasarguard"
+
+    if "panel" in per_file and "pasarguard" in per_file:
+        from app.services.env_migration import read_env_var
+
+        env = (
+            PASARGUARD_ENV.read_text(encoding="utf-8", errors="ignore")
+            if PASARGUARD_ENV.exists()
+            else ""
+        )
+        workers_raw = read_env_var(env, "UVICORN_WORKERS")
+        try:
+            workers = max(1, int((workers_raw or "1").strip()))
+        except ValueError:
+            workers = 1
+        nats_on = (read_env_var(env, "NATS_ENABLED") or "").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+        if workers > 1 or nats_on:
+            return "panel"
+        return "pasarguard"
+
+    return per_file[0]
 
 
 def _discover_compose_profiles() -> list[str]:
@@ -1560,7 +1631,7 @@ def _discover_compose_profiles() -> list[str]:
 
 
 def _compose_cmd(*args: str, profiles: list[str] | None = None) -> list[str]:
-    cmd: list[str] = ["docker", "compose"]
+    cmd: list[str] = ["docker", "compose", *compose_file_prefix()]
     for profile in profiles or []:
         cmd.extend(["--profile", profile])
     env_file = PASARGUARD_ENV if PASARGUARD_ENV.exists() else PASARGUARD_DIR / ".env"

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -1474,18 +1474,20 @@ def _set_env_var(text: str, key: str, value: str | None) -> str:
 
 
 async def _compose(job: MigrationJob, *args: str, timeout: int = 300) -> tuple[bool, str]:
+    return await _run(job, _compose_argv(*args), cwd=str(PASARGUARD_DIR), timeout=timeout)
+
+
+def _compose_argv(*args: str) -> list[str]:
+    """docker compose with active compose file prefix (main + multi overlay when present)."""
     from app.services.pasarguard_ops import compose_file_prefix
 
-    prefix = compose_file_prefix()
-    return await _run(job, ["docker", "compose", *prefix, *args], cwd=str(PASARGUARD_DIR), timeout=timeout)
+    return ["docker", "compose", *compose_file_prefix(), *args]
 
 
 def _compose_has_service(name: str) -> bool:
-    compose = PASARGUARD_DIR / "docker-compose.yml"
-    if not compose.exists() or not name:
-        return False
-    text = compose.read_text(encoding="utf-8", errors="ignore")
-    return bool(re.search(rf"^\s*{re.escape(name)}\s*:", text, re.MULTILINE))
+    from app.services.multiworker_stack import compose_has_service
+
+    return compose_has_service(name)
 
 
 async def _compose_up_services(job: MigrationJob, *services: str, timeout: int = 300) -> tuple[bool, str]:
@@ -1507,7 +1509,12 @@ def _mysql_client_bins(db_type: str, svc: str | None = None) -> list[str]:
 
 
 async def _detect_db_container(job: MigrationJob, db_type: str) -> str | None:
-    ok, out = await _run(job, ["docker", "compose", "ps", "--services"], cwd=str(PASARGUARD_DIR), timeout=30)
+    ok, out = await _run(
+        job,
+        _compose_argv("ps", "--services"),
+        cwd=str(PASARGUARD_DIR),
+        timeout=30,
+    )
     services = set((out or "").split())
     candidates = {
         "timescaledb": ["timescaledb", "postgresql", "postgres"],
@@ -1532,12 +1539,12 @@ async def _detect_db_container(job: MigrationJob, db_type: str) -> str | None:
 async def _read_timescaledb_version(job: MigrationJob, container: str, password: str, user: str = "postgres") -> str | None:
     ok, out = await _run(
         job,
-        [
-            "docker", "compose", "exec", "-T",
+        _compose_argv(
+            "exec", "-T",
             "-e", f"PGPASSWORD={password}", container,
             "psql", "-U", user, "-d", "postgres", "-At",
             "-c", "SELECT default_version FROM pg_available_extensions WHERE name = 'timescaledb';",
-        ],
+        ),
         cwd=str(PASARGUARD_DIR),
         timeout=30,
     )
@@ -1560,9 +1567,11 @@ async def _wait_for_postgres_ready(
     while asyncio.get_event_loop().time() < deadline:
         attempt += 1
         proc = await asyncio.create_subprocess_exec(
-            "docker", "compose", "exec", "-T",
-            "-e", f"PGPASSWORD={password}",
-            svc, "psql", "-U", user, "-d", "postgres", "-c", "SELECT 1;",
+            *_compose_argv(
+                "exec", "-T",
+                "-e", f"PGPASSWORD={password}",
+                svc, "psql", "-U", user, "-d", "postgres", "-c", "SELECT 1;",
+            ),
             cwd=str(PASARGUARD_DIR),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
@@ -1671,7 +1680,9 @@ async def _align_timescaledb_image(job: MigrationJob, wanted: str, *, wipe_data:
         )
 
     job.set_progress(28, "Recreating TimescaleDB with matching version...")
-    await _compose(job, "stop", "pasarguard", timeout=120)
+    from app.services.multiworker_stack import stop_panel_stack
+
+    await stop_panel_stack(job)
     stop_svcs = ["timescaledb"]
     if _compose_has_service("pgbouncer"):
         stop_svcs.append("pgbouncer")
@@ -1930,7 +1941,7 @@ async def _read_pg_container_init_env(
     for key in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"):
         ok, raw = await _run(
             job,
-            ["docker", "compose", "exec", "-T", svc, "printenv", key],
+            _compose_argv("exec", "-T", svc, "printenv", key),
             cwd=str(PASARGUARD_DIR),
             timeout=15,
             quiet=True,
@@ -1967,12 +1978,13 @@ def _compose_looks_usable(text: str) -> bool:
 
 async def _resolve_running_db_container_id(job: MigrationJob, svc: str) -> str | None:
     """Find a running container id/name when ``docker compose exec`` is unusable."""
-    # Prefer compose mapping when compose file is still valid.
-    compose = PASARGUARD_DIR / "docker-compose.yml"
-    if compose.is_file() and _compose_looks_usable(compose.read_text(encoding="utf-8", errors="ignore")):
+    from app.services.pasarguard_ops import _active_compose_paths
+
+    paths = _active_compose_paths()
+    if paths:
         ok, out = await _run(
             job,
-            ["docker", "compose", "ps", "-q", svc],
+            _compose_argv("ps", "-q", svc),
             cwd=str(PASARGUARD_DIR),
             timeout=20,
             quiet=True,
@@ -2014,7 +2026,7 @@ async def _psql_in_db_container(
     timeout: int = 30,
 ) -> tuple[bool, str]:
     """Run psql inside the DB container; fall back to ``docker exec`` if compose is broken."""
-    cmd = ["docker", "compose", "exec", "-T"]
+    cmd = _compose_argv("exec", "-T")
     if password is not None:
         cmd.extend(["-e", f"PGPASSWORD={password}"])
     cmd.extend(
@@ -2458,11 +2470,14 @@ async def _ensure_timescaledb_not_in_restore_mode(
 
 async def _heal_panel_auth_if_needed(job: MigrationJob, password: str, user: str, db_name: str, db_type: str) -> None:
     """If panel crash-loops on SASL/password, re-sync roles and restart."""
+    from app.services.pasarguard_ops import panel_compose_service
+
     if db_type not in ("postgresql", "timescaledb", "mysql", "mariadb"):
         return
+    panel = panel_compose_service()
     ok, logs = await _run(
         job,
-        ["docker", "compose", "logs", "--tail", "80", "pasarguard"],
+        _compose_argv("logs", "--tail", "80", panel),
         cwd=str(PASARGUARD_DIR),
         timeout=40,
     )
@@ -2483,11 +2498,11 @@ async def _heal_panel_auth_if_needed(job: MigrationJob, password: str, user: str
                 db_type=db_type,
                 db_name=db_name or "pasarguard",
             )
-    await _compose(job, "up", "-d", "--force-recreate", "pasarguard", timeout=120)
+    await _compose(job, "up", "-d", "--force-recreate", panel, timeout=120)
     await asyncio.sleep(6)
     ok2, logs2 = await _run(
         job,
-        ["docker", "compose", "logs", "--tail", "40", "pasarguard"],
+        _compose_argv("logs", "--tail", "40", panel),
         cwd=str(PASARGUARD_DIR),
         timeout=40,
     )

--- a/app/static/backup.html
+++ b/app/static/backup.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG Backup</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=4.4.1">
-  <link rel="stylesheet" href="/static/css/backup.css?v=4.4.1">
+  <link rel="stylesheet" href="/static/css/style.css?v=4.4.2">
+  <link rel="stylesheet" href="/static/css/backup.css?v=4.4.2">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Vazirmatn:wght@400;500;600;700&display=swap" media="print" onload="this.media='all'">
@@ -35,7 +35,7 @@
         </div>
         <div class="header-titles">
           <h1>PGClockMG Backup</h1>
-          <p class="header-version" id="appVersion">v4.4.1</p>
+          <p class="header-version" id="appVersion">v4.4.2</p>
         </div>
       </div>
       <div class="header-meta">
@@ -564,6 +564,6 @@
     </div>
   </div>
 
-  <script src="/static/js/backup.js?v=4.4.1"></script>
+  <script src="/static/js/backup.js?v=4.4.2"></script>
 </body>
 </html>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=4.4.1">
+  <link rel="stylesheet" href="/static/css/style.css?v=4.4.2">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v4.4.1</p>
+          <p class="header-version" id="appVersion">v4.4.2</p>
         </div>
       </div>
       <div class="header-meta">
@@ -633,9 +633,9 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=4.4.1"></script>
-  <script src="/static/js/app.js?v=4.4.1"></script>
-  <script src="/static/js/wizard-flow.js?v=4.4.1"></script>
+  <script src="/static/js/i18n.js?v=4.4.2"></script>
+  <script src="/static/js/app.js?v=4.4.2"></script>
+  <script src="/static/js/wizard-flow.js?v=4.4.2"></script>
 </body>
 </html>
 

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="4.4.1"
+readonly SCRIPT_VERSION="4.4.2"
 readonly INSTALL_DIR="${PG_MIGRATOR_INSTALL_DIR:-/opt/pg-migrator}"
 readonly BACKUP_INSTALL_DIR="${PG_BACKUP_INSTALL_DIR:-/opt/pg-backup}"
 readonly SERVICE_NAME="pg-migrator"

--- a/tests/test_multiworker_restore.py
+++ b/tests/test_multiworker_restore.py
@@ -72,9 +72,9 @@ def test_detect_nats_disabled_skips_orchestration():
         patch.object(mws, "resolve_pasarguard_service", return_value="panel"),
     ):
         info = mws.detect_multiworker_stack(env)
-    assert info["orchestrate"] is True  # satellites still present
+    assert info["orchestrate"] is False
     assert info["uses_nats"] is False
-    print("OK: NATS disabled → uses_nats false")
+    print("OK: NATS disabled + single worker → no orchestration")
 
 
 def test_align_nats_env_fixes_localhost():
@@ -128,7 +128,7 @@ def test_start_panel_stack_single_worker():
     print("OK: single-worker start unchanged")
 
 
-def test_compose_file_prefix_uses_multi_when_nats_only_there():
+def test_compose_file_prefix_uses_both_main_and_multi():
     import tempfile
     import shutil
     from app.services import pasarguard_ops as po
@@ -138,20 +138,33 @@ def test_compose_file_prefix_uses_multi_when_nats_only_there():
     po.PASARGUARD_DIR = td
     try:
         (td / "docker-compose.yml").write_text(
-            "services:\n  timescaledb:\n    image: x\n", encoding="utf-8"
+            "services:\n  timescaledb:\n    image: x\n  pasarguard:\n    image: p\n",
+            encoding="utf-8",
         )
         (td / "docker-compose.multi.yml").write_text(
             "services:\n  nats:\n    image: nats\n  panel:\n    image: p\n",
             encoding="utf-8",
         )
         prefix = po.compose_file_prefix()
-        assert prefix == ["-f", str(td / "docker-compose.multi.yml")]
+        assert prefix == [
+            "-f", str(td / "docker-compose.yml"),
+            "-f", str(td / "docker-compose.multi.yml"),
+        ]
+        assert mws.compose_has_service("timescaledb") is True
         assert mws.compose_has_service("nats") is True
-        assert po.panel_compose_service() == "panel"
+        old_env = po.PASARGUARD_ENV
+        (td / ".env").write_text("UVICORN_WORKERS=4\nNATS_ENABLED=1\n", encoding="utf-8")
+        po.PASARGUARD_ENV = td / ".env"
+        try:
+            assert po.resolve_pasarguard_service() == "panel"
+            (td / ".env").write_text("UVICORN_WORKERS=1\nNATS_ENABLED=0\n", encoding="utf-8")
+            assert po.resolve_pasarguard_service() == "pasarguard"
+        finally:
+            po.PASARGUARD_ENV = old_env
     finally:
         po.PASARGUARD_DIR = old
         shutil.rmtree(td, ignore_errors=True)
-    print("OK: compose prefix selects multi file")
+    print("OK: compose prefix merges main + multi")
 
 
 def test_start_panel_stack_multi_worker():
@@ -185,6 +198,20 @@ def test_start_panel_stack_multi_worker():
     print("OK: multi-worker start order nats → panel → satellites")
 
 
+def test_bare_traceback_not_treated_as_failure():
+    from app.services.pasarguard_ops import _check_logs_for_failure
+
+    blob = "\n".join([
+        "panel-1 | Traceback (most recent call last):",
+        "panel-1 |   File \"main.py\", line 1, in <module>",
+        "panel-1 |     raise x",
+    ])
+    assert _check_logs_for_failure(blob) is None
+    blob2 = blob + "\npanel-1 | RuntimeError: NATS is required when running more than 1 worker."
+    assert _check_logs_for_failure(blob2) is not None
+    print("OK: bare traceback ignored until exception line")
+
+
 def test_extract_failure_snippet_includes_exception_line():
     from app.services.pasarguard_ops import _extract_failure_snippet
 
@@ -207,7 +234,8 @@ if __name__ == "__main__":
     test_align_nats_env_noop_without_nats_service()
     test_panel_stack_stop_order()
     test_start_panel_stack_single_worker()
-    test_compose_file_prefix_uses_multi_when_nats_only_there()
+    test_compose_file_prefix_uses_both_main_and_multi()
     test_start_panel_stack_multi_worker()
+    test_bare_traceback_not_treated_as_failure()
     test_extract_failure_snippet_includes_exception_line()
     print("\nAll multiworker restore tests passed")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Thorough re-audit of multi-worker / NATS restore paths after v4.4.1. Fixes remaining edge cases without breaking single-worker or all-in-one restores.

## Root causes fixed

1. **Dual compose files** — When `docker-compose.multi.yml` held NATS/panel but `docker-compose.yml` held TimescaleDB, compose commands could target only the overlay and miss DB services. Now both files are merged when the overlay defines worker-stack services.

2. **Panel vs pasarguard service name** — When both services exist across base + overlay, service selection now follows `.env` (`UVICORN_WORKERS`, `NATS_ENABLED`) so single-worker stacks keep using `pasarguard`.

3. **Orchestration scope** — NATS/node-worker/scheduler orchestration runs only when `workers > 1` or NATS is required, not merely because satellite services are defined in compose.

4. **Compose prefix gaps** — Restore-path `docker compose exec/ps/logs` calls now consistently include the active compose file prefix.

5. **Health check noise** — Bare `Traceback` headers during multi-worker Uvicorn boot no longer fail health checks; multi-worker success requires `Application startup complete` (not just `Uvicorn running`).

## Scenarios covered

- All-in-one single worker (`pasarguard` only) — unchanged
- Multi-worker with NATS (`panel` + overlay) — full stack boot + stricter health
- Base DB in main + workers in multi — both compose files used
- Multi compose present but `UVICORN_WORKERS=1` — stays on single-worker path

## Tests

- Updated `tests/test_multiworker_restore.py` for dual compose merge, service resolution, orchestration guard, and Traceback handling
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05dde-9b6c-7db2-9fc9-0d0721f35d66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05dde-9b6c-7db2-9fc9-0d0721f35d66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

