### PR TITLE
fix blank panel UI (missing texts/buttons) — v4.4.5

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> 🚀 **`v4.4.4`** — Prevent startup failed: DB sync + PgBouncer recreate + NATS before boot
+> 🚀 **`v4.4.5`** — Fix blank panel UI (missing text/buttons) + prevent startup failed
 > ⚠️ Always take a full backup before restore or migration.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> 🚀 **`v4.4.4`** — جلوگیری از startup failed: sync DB + recreate PgBouncer + NATS قبل از boot
+> 🚀 **`v4.4.5`** — فیکس لود خالی پنل (متن/دکمه) + جلوگیری از startup failed
 > ⚠️ قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> 🚀 **`v4.4.4`** — Предотвращение startup failed: sync DB + recreate PgBouncer + NATS до boot
+> 🚀 **`v4.4.5`** — Исправление пустой панели (текст/кнопки) + предотвращение startup failed
 > ⚠️ Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">

--- a/app/backup_main.py
+++ b/app/backup_main.py
@@ -43,7 +43,7 @@ from app.services.backup_telegram import (
 )
 from app.services.prerequisites import get_system_status, is_pasarguard_installed
 
-APP_VERSION = "4.4.4"
+APP_VERSION = "4.4.5"
 
 
 def _dashboard_update_info() -> dict:

--- a/app/main.py
+++ b/app/main.py
@@ -36,7 +36,7 @@ from app.services.self_uninstall import uninstall_preview, schedule_self_uninsta
 from app.services.auth import COOKIE_NAME, COOKIE_MAX_AGE, ensure_token, token_matches
 from app.config import WEB_PORT
 
-APP_VERSION = "4.4.4"
+APP_VERSION = "4.4.5"
 
 
 @asynccontextmanager
@@ -53,6 +53,26 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 PUBLIC_PATHS = frozenset({"/login", "/favicon.ico"})
 
+# JS/CSS/fonts must load even when the auth cookie is missing/expired.
+# Otherwise the browser executes the HTML login page as JavaScript → blank UI
+# (empty labels/buttons). HTML shells under /static stay protected.
+_STATIC_ASSET_SUFFIXES = (
+    ".js",
+    ".css",
+    ".map",
+    ".svg",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".gif",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".otf",
+    ".ico",
+)
+
 
 def _is_public_path(path: str) -> bool:
     if path in PUBLIC_PATHS:
@@ -60,6 +80,9 @@ def _is_public_path(path: str) -> bool:
     # One-time stream receive tokens authenticate the request themselves.
     if path.startswith("/api/stream/receive/"):
         return True
+    if path.startswith("/static/"):
+        lower = path.lower()
+        return lower.endswith(_STATIC_ASSET_SUFFIXES)
     return False
 
 _LOGIN_PAGE = """<!doctype html>

--- a/app/static/backup.html
+++ b/app/static/backup.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG Backup</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=4.4.4">
-  <link rel="stylesheet" href="/static/css/backup.css?v=4.4.4">
+  <link rel="stylesheet" href="/static/css/style.css?v=4.4.5">
+  <link rel="stylesheet" href="/static/css/backup.css?v=4.4.5">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Vazirmatn:wght@400;500;600;700&display=swap" media="print" onload="this.media='all'">
@@ -16,11 +16,52 @@
     html.is-booting .panel { display: none !important; }
     html.is-booting .backup-tabs,
     html.is-booting #btnLogout { visibility: hidden; }
+    .boot-splash {
+      display: none;
+      min-height: 40vh;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      gap: 10px;
+      color: #9aa3b5;
+      font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+    }
+    html.is-booting .boot-splash { display: flex; }
+    .boot-splash-dot {
+      width: 28px; height: 28px; border-radius: 50%;
+      border: 2px solid #3d7dff; border-top-color: transparent;
+      animation: bootspin 0.8s linear infinite;
+    }
+    @keyframes bootspin { to { transform: rotate(360deg); } }
   </style>
 </head>
 <body>
-  <script>document.documentElement.classList.add("is-booting");</script>
+  <script>
+    document.documentElement.classList.add("is-booting");
+    // Last-resort reveal if backup.js fails to load/parse (blank UI otherwise).
+    window.__pgBootSafety = setTimeout(function () {
+      var root = document.documentElement;
+      if (!root.classList.contains("is-booting")) return;
+      root.classList.remove("is-booting");
+      document.body.classList.add("is-booted");
+      var splash = document.getElementById("bootSplash");
+      if (splash) splash.hidden = true;
+      var auth = document.getElementById("panel-auth");
+      if (auth && !document.querySelector(".panel.active")) auth.classList.add("active");
+    }, 6000);
+  </script>
+  <noscript>
+    <div style="max-width:420px;margin:15vh auto;padding:24px;background:#182031;color:#e6e9ef;border-radius:12px;font-family:system-ui,sans-serif;line-height:1.6">
+      JavaScript is required for PGClockMG Backup / برای پنل بکاپ باید JavaScript فعال باشد.
+    </div>
+  </noscript>
   <div class="app backup-app">
+    <div id="bootSplash" class="boot-splash" role="status" aria-live="polite">
+      <div class="boot-splash-dot" aria-hidden="true"></div>
+      <span>Loading…</span>
+    </div>
 
     <header class="header">
       <div class="header-brand">
@@ -35,7 +76,7 @@
         </div>
         <div class="header-titles">
           <h1>PGClockMG Backup</h1>
-          <p class="header-version" id="appVersion">v4.4.4</p>
+          <p class="header-version" id="appVersion">v4.4.5</p>
         </div>
       </div>
       <div class="header-meta">
@@ -84,13 +125,13 @@
             <div class="choice-icon icon-tone-orange" aria-hidden="true">
               <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
             </div>
-            <h2 id="authTitle"></h2>
-            <p class="desc" id="authDesc"></p>
+            <h2 id="authTitle">ورود به پنل بکاپ</h2>
+            <p class="desc" id="authDesc">با رمز همین پنل وارد شوید.</p>
           </div>
           <div class="welcome-body">
             <div id="authError" class="warning-card hidden"></div>
             <div class="form-group">
-              <label id="lblPassword"></label>
+              <label id="lblPassword">رمز عبور</label>
               <input type="password" id="authPassword" autocomplete="new-password" class="text-input">
             </div>
             <div class="form-group hidden" id="authConfirmWrap">
@@ -104,7 +145,7 @@
               <p class="desc-sm" id="authSetupTokenHint"></p>
             </div>
             <div class="actions actions-center">
-              <button type="button" class="btn btn-primary" id="btnAuthSubmit" onclick="submitAuth()"></button>
+              <button type="button" class="btn btn-primary" id="btnAuthSubmit" onclick="submitAuth()">ورود</button>
             </div>
           </div>
         </div>
@@ -564,6 +605,6 @@
     </div>
   </div>
 
-  <script src="/static/js/backup.js?v=4.4.4"></script>
+  <script src="/static/js/backup.js?v=4.4.5"></script>
 </body>
 </html>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=4.4.4">
+  <link rel="stylesheet" href="/static/css/style.css?v=4.4.5">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -13,6 +13,11 @@
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Vazirmatn:wght@400;500;600;700&display=swap"></noscript>
 </head>
 <body>
+  <noscript>
+    <div style="max-width:420px;margin:15vh auto;padding:24px;background:#182031;color:#e6e9ef;border-radius:12px;font-family:system-ui,sans-serif;line-height:1.6">
+      JavaScript is required for PGClockMG / برای ویزارد باید JavaScript فعال باشد.
+    </div>
+  </noscript>
   <div class="app">
 
     <header class="header">
@@ -37,7 +42,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v4.4.4</p>
+          <p class="header-version" id="appVersion">v4.4.5</p>
         </div>
       </div>
       <div class="header-meta">
@@ -63,8 +68,8 @@
       <section class="panel active" id="panel-welcome">
         <div class="welcome-card">
           <div class="welcome-header">
-            <h2 id="welcomeH2"></h2>
-            <p class="desc" id="welcomeDesc"></p>
+            <h2 id="welcomeH2">PGClockMG</h2>
+            <p class="desc" id="welcomeDesc">ویزارد ریستور و مهاجرت</p>
           </div>
           <div class="welcome-body">
             <p class="welcome-note" id="welcomeNote"></p>
@@ -75,21 +80,21 @@
                 <span class="choice-icon" aria-hidden="true">
                   <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M12 3v12"/><path d="M8 11l4 4 4-4"/><path d="M4 19h16"/></svg>
                 </span>
-                <strong id="welcomeGoalInstall"></strong>
+                <strong id="welcomeGoalInstall">نصب / راهنما</strong>
                 <span id="welcomeGoalInstallDesc"></span>
               </button>
               <button type="button" class="choice-card choice-card-lg" onclick="startWizardGoal('change_db')">
                 <span class="choice-icon" aria-hidden="true">
                   <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><ellipse cx="12" cy="6" rx="7" ry="3"/><path d="M5 6v6c0 1.7 3.1 3 7 3s7-1.3 7-3V6"/><path d="M5 12v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6"/></svg>
                 </span>
-                <strong id="welcomeGoalChangeDb"></strong>
+                <strong id="welcomeGoalChangeDb">تغییر دیتابیس</strong>
                 <span id="welcomeGoalChangeDbDesc"></span>
               </button>
               <button type="button" class="choice-card choice-card-lg" onclick="startWizardGoal('migrate')">
                 <span class="choice-icon" aria-hidden="true">
                   <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M16 3h5v5"/><path d="M4 20L21 3"/><path d="M21 16v5h-5"/><path d="M15 15l6 6"/><path d="M4 4l5 5"/></svg>
                 </span>
-                <strong id="welcomeGoalMigrate"></strong>
+                <strong id="welcomeGoalMigrate">مهاجرت</strong>
                 <span id="welcomeGoalMigrateDesc"></span>
               </button>
             </div>
@@ -633,9 +638,9 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=4.4.4"></script>
-  <script src="/static/js/app.js?v=4.4.4"></script>
-  <script src="/static/js/wizard-flow.js?v=4.4.4"></script>
+  <script src="/static/js/i18n.js?v=4.4.5"></script>
+  <script src="/static/js/app.js?v=4.4.5"></script>
+  <script src="/static/js/wizard-flow.js?v=4.4.5"></script>
 </body>
 </html>
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,7 +1,20 @@
 /* PG-Migrator Wizard */
 
+function _safeStorageGet(key, fallback) {
+  try {
+    const value = localStorage.getItem(key);
+    return value == null ? fallback : value;
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function _safeStorageSet(key, value) {
+  try { localStorage.setItem(key, value); } catch (_) {}
+}
+
 const state = {
-  lang: localStorage.getItem('pg-migrator-lang') || 'fa',
+  lang: _safeStorageGet('pg-migrator-lang', 'fa') || 'fa',
   currentStep: 0,
   panels: [],
   subscriptionLabels: {},

--- a/app/static/js/backup.js
+++ b/app/static/js/backup.js
@@ -640,7 +640,25 @@ const I18N = {
   },
 };
 
-let lang = localStorage.getItem("pg_backup_lang") || "fa";
+/** localStorage can throw in private/restricted browsers — never kill the panel script. */
+function storageGet(key, fallback) {
+  try {
+    const value = localStorage.getItem(key);
+    return value == null ? fallback : value;
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function storageSet(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (_) {
+    /* ignore quota / privacy mode */
+  }
+}
+
+let lang = storageGet("pg_backup_lang", "fa") || "fa";
 let setupMode = false;
 let pollTimer = null;
 let backupProgressFadeTimer = null;
@@ -750,11 +768,13 @@ function t(key) {
 
 function setBackupLang(next) {
   lang = next;
-  localStorage.setItem("pg_backup_lang", next);
+  storageSet("pg_backup_lang", next);
   document.documentElement.lang = next;
   document.documentElement.dir = next === "fa" ? "rtl" : "ltr";
   syncLangMenu(next);
   applyI18n();
+  // Skip dashboard refresh while panels are still hidden for boot.
+  if (document.documentElement.classList.contains("is-booting")) return;
   if (!document.getElementById("panel-auth")?.classList.contains("active")) {
     refreshDashboard().catch(() => {});
     if (document.getElementById("panel-list")?.classList.contains("active")) {
@@ -905,21 +925,36 @@ function applyI18n() {
   document.getElementById("btnAuthSubmit").textContent = setupMode ? t("btnSetup") : t("btnLogin");
 }
 
+const API_TIMEOUT_MS = 10000;
+
 async function api(path, opts = {}) {
+  const timeoutMs = Number(opts.timeoutMs) > 0 ? Number(opts.timeoutMs) : API_TIMEOUT_MS;
+  const fetchOpts = { ...opts };
+  delete fetchOpts.timeoutMs;
+
+  const ctrl = typeof AbortController !== "undefined" ? new AbortController() : null;
+  const timer = ctrl ? setTimeout(() => ctrl.abort(), timeoutMs) : null;
   let res;
   try {
     res = await fetch(path, {
       credentials: "same-origin",
-      headers: { "Content-Type": "application/json", ...(opts.headers || {}) },
-      ...opts,
+      headers: { "Content-Type": "application/json", ...(fetchOpts.headers || {}) },
+      ...fetchOpts,
+      signal: ctrl ? ctrl.signal : fetchOpts.signal,
     });
   } catch (e) {
     const raw = (e && e.message) || "";
+    const name = (e && e.name) || "";
     // Safari/WebKit often reports transient fetch failures as "Load failed".
-    if (/load failed|failed to fetch|networkerror|network request failed/i.test(raw)) {
+    if (
+      name === "AbortError"
+      || /load failed|failed to fetch|networkerror|network request failed|aborted/i.test(raw)
+    ) {
       throw new Error(t("errNetwork"));
     }
     throw new Error(raw || t("errNetwork"));
+  } finally {
+    if (timer) clearTimeout(timer);
   }
   let data = null;
   const ct = res.headers.get("content-type") || "";
@@ -1024,14 +1059,25 @@ function esc(s) {
 }
 
 async function boot() {
-  setBackupLang(lang);
+  let settled = false;
+  const safety = setTimeout(() => {
+    if (settled) return;
+    // Never leave the UI blank if setup/session probes hang on slow links.
+    finishBoot();
+    if (!document.querySelector(".panel.active")) showPanel("panel-auth");
+  }, 5000);
+  window.__pgBootSafety = safety;
+
   try {
-    const st = await api("/api/setup/status");
-    document.getElementById("appVersion").textContent = "v" + (st.version || "4.3.2");
+    // Paint i18n first while panels are still hidden, then reveal ASAP.
+    setBackupLang(lang);
+    const st = await api("/api/setup/status", { timeoutMs: 8000 });
+    const verEl = document.getElementById("appVersion");
+    if (verEl) verEl.textContent = "v" + (st.version || "4.4.5");
     setupMode = !st.password_set;
     window.__setupTokenRequired = !!st.setup_token_required;
-    document.getElementById("authConfirmWrap").classList.toggle("hidden", !setupMode);
-    document.getElementById("authSetupTokenWrap").classList.toggle(
+    document.getElementById("authConfirmWrap")?.classList.toggle("hidden", !setupMode);
+    document.getElementById("authSetupTokenWrap")?.classList.toggle(
       "hidden",
       !(setupMode && window.__setupTokenRequired)
     );
@@ -1040,15 +1086,18 @@ async function boot() {
     if (!setupMode) {
       try {
         // Lightweight session probe — do not load the heavy dashboard twice.
-        await api("/api/session");
+        await api("/api/session", { timeoutMs: 5000 });
+        settled = true;
         finishBoot();
         enterApp();
         return;
       } catch (_) { /* need login */ }
     }
+    settled = true;
     finishBoot();
     showPanel("panel-auth");
   } catch (e) {
+    settled = true;
     finishBoot();
     showPanel("panel-auth");
     const err = document.getElementById("authError");
@@ -1056,13 +1105,26 @@ async function boot() {
       err.textContent = e.message || String(e);
       err.classList.remove("hidden");
     }
+  } finally {
+    if (!settled) {
+      settled = true;
+      finishBoot();
+      if (!document.querySelector(".panel.active")) showPanel("panel-auth");
+    }
   }
 }
 
 function finishBoot() {
+  if (window.__pgBootSafety) {
+    clearTimeout(window.__pgBootSafety);
+    window.__pgBootSafety = null;
+  }
   document.documentElement.classList.remove("is-booting");
   document.body.classList.add("is-booted");
+  const splash = document.getElementById("bootSplash");
+  if (splash) splash.hidden = true;
 }
+
 
 function enterApp() {
   showBackupTab("dash");

--- a/app/static/js/i18n.js
+++ b/app/static/js/i18n.js
@@ -1481,7 +1481,7 @@ function applySocialI18n() {
 
 function setLang(lang) {
   state.lang = lang;
-  localStorage.setItem('pg-migrator-lang', lang);
+  try { localStorage.setItem('pg-migrator-lang', lang); } catch (_) {}
   document.documentElement.lang = lang;
   document.documentElement.dir = lang === 'fa' ? 'rtl' : 'ltr';
   syncLangSwitch(lang);

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="4.4.4"
+readonly SCRIPT_VERSION="4.4.5"
 readonly INSTALL_DIR="${PG_MIGRATOR_INSTALL_DIR:-/opt/pg-migrator}"
 readonly BACKUP_INSTALL_DIR="${PG_BACKUP_INSTALL_DIR:-/opt/pg-backup}"
 readonly SERVICE_NAME="pg-migrator"

--- a/tests/test_access_token.py
+++ b/tests/test_access_token.py
@@ -26,7 +26,6 @@ PROTECTED_GETS = (
     "/api/pasarguard/status",
     "/api/upload/whatever/analysis",
     "/api/self-uninstall",
-    "/static/js/app.js",
 )
 
 
@@ -135,3 +134,17 @@ def test_env_token_is_persisted_to_disk(tmp_path, monkeypatch):
     token = ensure_token()
     assert token == "abcdef0123456789abcdef0123456789abcdef0123456789"
     assert token_file.read_text(encoding="utf-8").strip() == token
+
+def test_static_assets_are_public_without_token(client):
+    """JS/CSS must not depend on the auth cookie — otherwise UI boots empty."""
+    for path in ("/static/js/app.js", "/static/js/i18n.js", "/static/css/style.css"):
+        r = client.get(path)
+        assert r.status_code == 200, path
+        assert "text/html" not in (r.headers.get("content-type") or "").lower()
+
+
+def test_static_html_shells_still_require_token(client):
+    # Asset public rule must not expose the HTML shells under /static/.
+    assert client.get("/static/index.html").status_code == 401
+    assert client.get("/static/backup.html").status_code == 401
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes intermittent reports where the wizard/backup panel loaded without texts and buttons.

### Causes addressed
1. **Wizard `/static` JS/CSS behind access-token auth** — when the cookie was missing/expired, `/static/js/*.js` returned the HTML login page and the browser failed to execute it → empty labels/buttons.
2. **Backup `is-booting` hid all panels until API boot finished** — setup/session probes had no timeout, so slow/hung requests left a blank UI.
3. **Hard dependency on JS i18n with empty HTML** — no splash/fallback if boot stalled or JS failed.
4. **`localStorage` throws in restricted/private modes** could abort script init before i18n ran.

### Fixes (no restore/migrate/backup engine changes)
- Public static **assets** (js/css/fonts/images) on the wizard; HTML shells under `/static/*.html` stay protected.
- Backup boot: API timeouts, safety reveal timer, splash + inline last-resort timer, auth HTML fallback copy, safe `localStorage` helpers.
- Wizard: safe `localStorage` + noscript + first-screen fallback copy.
- Tests updated for public assets / protected HTML shells.
- Version bump to **v4.4.5** (cache-bust query params).

### Verification
- `pytest tests/test_access_token.py tests/test_i18n_parity.py` → passed
- Live proof: `/static/js/app.js` returns `200 text/javascript` **without** token; `/` and `/static/index.html` still `401` without token
- Manual UI check: backup login/setup and wizard welcome both show labels/buttons after load
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0764c-c40f-78d2-a54d-f110356e0169?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0764c-c40f-78d2-a54d-f110356e0169&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

