### PR TITLE
fix(marzban): clearer MySQL import exit 137 diagnostics (safe happy path)

### DIFF
--- a/app/services/migrators/marzban.py
+++ b/app/services/migrators/marzban.py
@@ -737,8 +737,18 @@ class MarzbanMigrator(BaseMigrator):
             f"({size_mb:.1f} MB — large dumps can take a long time)..."
         )
 
+        from app.services.mysql_import_diagnostics import (
+            classify_mysql_import_failure,
+            compose_service_diagnostics,
+            compose_service_oom_killed,
+            compose_service_running,
+            format_mysql_import_error,
+        )
+
         # Prefer exec+stdin over shell redirect so host paths outside mounts work
         # and passwords/special chars are not re-parsed by a shell.
+        # Happy path is unchanged: same argv, no import timeout, no session SETs.
+        container_died = False
         with fixed.open("rb") as fh:
             proc = await asyncio.create_subprocess_exec(
                 "docker", "compose", "exec", "-T", svc,
@@ -778,17 +788,46 @@ class MarzbanMigrator(BaseMigrator):
                         f"({size_mb:.0f} MB, {elapsed}s)...",
                     )
                     self.job.log(f"Still importing MySQL dump... ({elapsed}s elapsed)")
+                    # Best-effort liveness: only abort when the DB service is
+                    # definitively down. Probe failures return None and are ignored
+                    # so flaky docker CLI cannot break healthy imports.
+                    running = await compose_service_running(str(PASARGUARD_DIR), svc)
+                    if running is False:
+                        container_died = True
+                        self.job.log(
+                            f"DB service `{svc}` is no longer running during import — "
+                            f"stopping wait and collecting diagnostics"
+                        )
+                        try:
+                            proc.kill()
+                        except Exception:
+                            pass
+                        break
             await proc.wait()
             if not drain_task.done():
                 await drain_task
             elapsed = int(time.monotonic() - started)
 
-        if proc.returncode != 0:
-            tail = "\n".join(output_lines[-40:])
+        if proc.returncode != 0 or container_died:
+            # If we did not catch death mid-loop, still detect a dead service now.
+            if not container_died:
+                running = await compose_service_running(str(PASARGUARD_DIR), svc)
+                if running is False:
+                    container_died = True
+            oom = await compose_service_oom_killed(str(PASARGUARD_DIR), svc)
+            failure = classify_mysql_import_failure(
+                proc.returncode,
+                "\n".join(output_lines),
+                container_died=container_died,
+                oom_killed=oom,
+            )
+            diag = await compose_service_diagnostics(str(PASARGUARD_DIR), svc)
             raise RuntimeError(
-                f"Failed to import Marzban MySQL dump into PasarGuard "
-                f"(exit {proc.returncode}). Check DB credentials and container logs."
-                + (f"\n{tail}" if tail else "")
+                format_mysql_import_error(
+                    failure,
+                    output_tail="\n".join(output_lines[-40:]),
+                    diag_tail=diag,
+                )
             )
         self.job.log(f"MySQL dump import finished ({elapsed}s)")
         try:

--- a/app/services/migrators/marzban.py
+++ b/app/services/migrators/marzban.py
@@ -702,6 +702,23 @@ class MarzbanMigrator(BaseMigrator):
         changed = rewrite_mysql_dump_file_for_pasarguard(dump_file, fixed)
         self.job.log(f"Dump rewrite complete ({changed} lines changed)")
 
+        from app.services.mysql_import_diagnostics import (
+            assess_mysql_import_ram,
+            classify_mysql_import_failure,
+            compose_service_diagnostics,
+            compose_service_oom_killed,
+            compose_service_running,
+            format_mysql_import_error,
+            write_mysql_import_stdin_file,
+        )
+
+        # Advisory only — never aborts. Small dumps on healthy hosts stay quiet/ok.
+        ram_advice = assess_mysql_import_ram(fixed.stat().st_size)
+        if ram_advice.level == "warn":
+            self.job.log(f"WARNING: {ram_advice.message}")
+        else:
+            self.job.log(ram_advice.message)
+
         svc = resolve_db_service("mysql") or resolve_db_service("mariadb") or "mysql"
         await self._run_cmd(["docker", "compose", "up", "-d", svc], cwd=str(PASARGUARD_DIR))
         await self._wait_compose_mysql_ready(svc, user, pwd, host)
@@ -737,19 +754,28 @@ class MarzbanMigrator(BaseMigrator):
             f"({size_mb:.1f} MB — large dumps can take a long time)..."
         )
 
-        from app.services.mysql_import_diagnostics import (
-            classify_mysql_import_failure,
-            compose_service_diagnostics,
-            compose_service_oom_killed,
-            compose_service_running,
-            format_mysql_import_error,
-        )
+        # SESSION preamble on the same connection as the dump (FK/unique checks off).
+        # If preparing the combined file fails, fall back to the plain rewritten dump
+        # so a disk glitch cannot block an otherwise healthy migration.
+        import_path = fixed
+        session_file = dump_file.parent / "fixed_import_session.sql"
+        try:
+            write_mysql_import_stdin_file(fixed, session_file)
+            import_path = session_file
+            self.job.log(
+                "SESSION import preamble applied "
+                "(FOREIGN_KEY_CHECKS=0, UNIQUE_CHECKS=0; connection-local only)"
+            )
+        except OSError as exc:
+            self.job.log(
+                f"SESSION import preamble skipped — using plain rewritten dump ({exc})"
+            )
 
         # Prefer exec+stdin over shell redirect so host paths outside mounts work
         # and passwords/special chars are not re-parsed by a shell.
-        # Happy path is unchanged: same argv, no import timeout, no session SETs.
+        # Same argv as before; only the stdin file may include a tiny SESSION preamble.
         container_died = False
-        with fixed.open("rb") as fh:
+        with import_path.open("rb") as fh:
             proc = await asyncio.create_subprocess_exec(
                 "docker", "compose", "exec", "-T", svc,
                 "mysql", "-u", user, f"-p{pwd}", "-h", host, db,
@@ -830,11 +856,12 @@ class MarzbanMigrator(BaseMigrator):
                 )
             )
         self.job.log(f"MySQL dump import finished ({elapsed}s)")
-        try:
-            if fixed.exists() and fixed.resolve() != dump_file.resolve():
-                fixed.unlink()
-        except OSError:
-            pass
+        for path in (fixed, session_file):
+            try:
+                if path.exists() and path.resolve() != dump_file.resolve():
+                    path.unlink()
+            except OSError:
+                pass
 
     async def _update_env_paths(self, source_db: str, target_db: str):
         env_path = PASARGUARD_DIR / ".env"

--- a/app/services/mysql_import_diagnostics.py
+++ b/app/services/mysql_import_diagnostics.py
@@ -1,16 +1,32 @@
-"""Diagnostics for MySQL/MariaDB dump import failures (compose exec path).
+"""Diagnostics + safe helpers for MySQL/MariaDB dump import (compose exec path).
 
-Pure helpers + best-effort Docker probes. Must never change a successful import:
-callers use these only for heartbeats / error messages.
+Design rules for migration safety:
+- Advisory RAM preflight never blocks an import.
+- SESSION preamble uses only widely-supported session toggles (same ones
+  mysqldump itself emits); it dies with the import connection.
+- Docker probes are best-effort and must not abort healthy imports.
 """
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 MysqlImportKind = Literal["killed", "auth", "sql", "client", "unknown"]
+MysqlImportRamLevel = Literal["ok", "info", "warn"]
+
+# SESSION-only. No GLOBAL. No sql_log_bin / flush / sql_mode changes.
+# These match what official mysqldump headers typically set for bulk load.
+MYSQL_IMPORT_SESSION_PREAMBLE = (
+    "-- PGClockMG MySQL import session preamble (SESSION scope only)\n"
+    "SET SESSION FOREIGN_KEY_CHECKS=0;\n"
+    "SET SESSION UNIQUE_CHECKS=0;\n"
+)
+
+_MI = 1024 * 1024
+_GI = 1024 * _MI
 
 # docker/mysql client often surfaces 128+signal; asyncio may also report -signal.
 _SIGKILL_CODES = {137, -9, 128 + 9}
@@ -73,6 +89,118 @@ class MysqlImportFailure:
     exit_code: int | None
     summary: str
     guidance: str
+
+
+@dataclass(frozen=True)
+class MysqlImportRamAdvice:
+    """Advisory only — callers must log, never raise/abort on this."""
+
+    level: MysqlImportRamLevel
+    dump_bytes: int
+    mem_available_bytes: int | None
+    message: str
+
+
+def mysql_import_session_preamble_sql() -> str:
+    return MYSQL_IMPORT_SESSION_PREAMBLE
+
+
+def write_mysql_import_stdin_file(dump_path: Path, dest: Path) -> Path:
+    """Stream ``preamble + dump`` into ``dest`` without loading the dump in RAM.
+
+    Keeps the caller's ``stdin=file`` import path identical to before.
+    """
+    dump_path = Path(dump_path)
+    dest = Path(dest)
+    if not dump_path.is_file():
+        raise FileNotFoundError(f"MySQL dump not found: {dump_path}")
+    preamble = mysql_import_session_preamble_sql().encode("utf-8")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("wb") as out, dump_path.open("rb") as inp:
+        out.write(preamble)
+        while True:
+            chunk = inp.read(1024 * 1024)
+            if not chunk:
+                break
+            out.write(chunk)
+    return dest
+
+
+def read_mem_available_bytes() -> int | None:
+    """Best-effort MemAvailable from /proc; None if unreadable."""
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("MemAvailable:"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        return int(parts[1]) * 1024
+    except Exception:
+        return None
+    return None
+
+
+def assess_mysql_import_ram(
+    dump_bytes: int,
+    mem_available_bytes: int | None = None,
+) -> MysqlImportRamAdvice:
+    """Compare dump size to free RAM. Never means 'abort migration'."""
+    dump_bytes = max(0, int(dump_bytes or 0))
+    if mem_available_bytes is None:
+        mem_available_bytes = read_mem_available_bytes()
+
+    dump_mb = dump_bytes / _MI
+    if mem_available_bytes is None:
+        return MysqlImportRamAdvice(
+            "info",
+            dump_bytes,
+            None,
+            f"MySQL import preflight: dump {dump_mb:.1f} MiB; free RAM unknown "
+            f"(continuing — advisory only).",
+        )
+
+    free_mb = mem_available_bytes / _MI
+    # Soft thresholds only. Small dumps on healthy hosts stay at ok/info.
+    if mem_available_bytes < 256 * _MI:
+        return MysqlImportRamAdvice(
+            "warn",
+            dump_bytes,
+            mem_available_bytes,
+            f"MySQL import preflight: low free RAM ({free_mb:.0f} MiB) while importing "
+            f"{dump_mb:.1f} MiB dump. Continuing anyway; if import exits 137, add RAM/swap "
+            f"or check DB container OOM.",
+        )
+    # Large dump relative to free RAM (8x headroom heuristic).
+    if dump_bytes >= 50 * _MI and mem_available_bytes < max(512 * _MI, 8 * dump_bytes):
+        return MysqlImportRamAdvice(
+            "warn",
+            dump_bytes,
+            mem_available_bytes,
+            f"MySQL import preflight: dump {dump_mb:.1f} MiB is large vs free RAM "
+            f"({free_mb:.0f} MiB). Continuing anyway; watch for exit 137 / OOMKilled.",
+        )
+    if dump_bytes > mem_available_bytes:
+        return MysqlImportRamAdvice(
+            "warn",
+            dump_bytes,
+            mem_available_bytes,
+            f"MySQL import preflight: dump ({dump_mb:.1f} MiB) exceeds free RAM "
+            f"({free_mb:.0f} MiB). Continuing anyway; failure is more likely under memory pressure.",
+        )
+    if mem_available_bytes < 1 * _GI and dump_bytes >= 100 * _MI:
+        return MysqlImportRamAdvice(
+            "info",
+            dump_bytes,
+            mem_available_bytes,
+            f"MySQL import preflight: dump {dump_mb:.1f} MiB with {free_mb:.0f} MiB free RAM "
+            f"(continuing).",
+        )
+    return MysqlImportRamAdvice(
+        "ok",
+        dump_bytes,
+        mem_available_bytes,
+        f"MySQL import preflight: dump {dump_mb:.1f} MiB, free RAM {free_mb:.0f} MiB — ok.",
+    )
 
 
 def classify_mysql_import_failure(

--- a/app/services/mysql_import_diagnostics.py
+++ b/app/services/mysql_import_diagnostics.py
@@ -1,0 +1,310 @@
+"""Diagnostics for MySQL/MariaDB dump import failures (compose exec path).
+
+Pure helpers + best-effort Docker probes. Must never change a successful import:
+callers use these only for heartbeats / error messages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Literal
+
+MysqlImportKind = Literal["killed", "auth", "sql", "client", "unknown"]
+
+# docker/mysql client often surfaces 128+signal; asyncio may also report -signal.
+_SIGKILL_CODES = {137, -9, 128 + 9}
+_SIGTERM_CODES = {143, -15, 128 + 15}
+
+_AUTH_HINTS = (
+    "access denied",
+    "authentication failed",
+    "password: no",
+    "using password: yes",
+    "error 1045",
+    "error 1698",
+    "error 1044",
+)
+
+_SQL_HINTS = (
+    "error 1064",
+    "error 1146",
+    "error 1054",
+    "error 1005",
+    "error 1215",
+    "error 1452",
+    "syntax error",
+)
+
+_CONN_HINTS = (
+    "can't connect",
+    "can not connect",
+    "error 2002",
+    "error 2003",
+    "connection refused",
+    "gone away",
+    "server has gone away",
+    "not allowed to connect",
+)
+
+
+async def _communicate_timeout(
+    proc: asyncio.subprocess.Process,
+    timeout: float,
+) -> tuple[bytes, bytes]:
+    """communicate() with hard timeout; kill the probe so Docker CLI cannot leak."""
+    try:
+        return await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except (TimeoutError, asyncio.TimeoutError):
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=3)
+        except Exception:
+            pass
+        raise
+
+
+@dataclass(frozen=True)
+class MysqlImportFailure:
+    kind: MysqlImportKind
+    exit_code: int | None
+    summary: str
+    guidance: str
+
+
+def classify_mysql_import_failure(
+    exit_code: int | None,
+    output: str = "",
+    *,
+    container_died: bool = False,
+    oom_killed: bool | None = None,
+) -> MysqlImportFailure:
+    """Map exit code + client output to a stable failure kind (no I/O)."""
+    text = (output or "").strip()
+    low = text.lower()
+
+    if container_died or exit_code in _SIGKILL_CODES or exit_code in _SIGTERM_CODES:
+        if oom_killed is True:
+            summary = (
+                f"MySQL/MariaDB import was killed "
+                f"(exit {exit_code if exit_code is not None else 'unknown'}; "
+                f"container OOMKilled=true)."
+            )
+            guidance = (
+                "The database container ran out of memory mid-import. "
+                "This is not a DB password problem. Free RAM, add swap, or "
+                "raise the container memory limit, then retry "
+                "(the migrator recreates the target DB before each import)."
+            )
+        elif container_died:
+            summary = (
+                f"MySQL/MariaDB container stopped during dump import "
+                f"(exit {exit_code if exit_code is not None else 'unknown'})."
+            )
+            guidance = (
+                "The compose DB service exited while mysql was reading the dump. "
+                "Check container logs and host disk space. "
+                "Not a DB password problem — retry after the DB service stays up."
+            )
+        else:
+            summary = (
+                f"MySQL/MariaDB import process was killed "
+                f"(exit {exit_code if exit_code is not None else 'unknown'}; SIGKILL/SIGTERM)."
+            )
+            guidance = (
+                "Exit 137/143 usually means the mysql client or DB container was "
+                "SIGKILL'd (OOM, docker restart, or host killer) — not bad credentials. "
+                "Inspect compose DB logs and `dmesg` for OOM, then retry."
+            )
+        return MysqlImportFailure("killed", exit_code, summary, guidance)
+
+    if any(h in low for h in _AUTH_HINTS):
+        return MysqlImportFailure(
+            "auth",
+            exit_code,
+            f"MySQL/MariaDB rejected credentials during dump import (exit {exit_code}).",
+            "Verify MYSQL_ROOT_PASSWORD / DB user against /opt/pasarguard/.env "
+            "and that the compose mysql/mariadb service is the one being targeted.",
+        )
+
+    if any(h in low for h in _CONN_HINTS):
+        return MysqlImportFailure(
+            "client",
+            exit_code,
+            f"Could not reach MySQL/MariaDB during dump import (exit {exit_code}).",
+            "The DB service may have restarted or is not listening inside the container. "
+            "Check compose ps/logs; this is usually not a wrong password.",
+        )
+
+    if any(h in low for h in _SQL_HINTS):
+        return MysqlImportFailure(
+            "sql",
+            exit_code,
+            f"MySQL/MariaDB reported an SQL error during dump import (exit {exit_code}).",
+            "The dump may be truncated, incompatible, or partially rewritten. "
+            "Check the SQL error in the output below; a clean retry recreates the target DB first.",
+        )
+
+    if exit_code not in (None, 0):
+        return MysqlImportFailure(
+            "client",
+            exit_code,
+            f"Failed to import MySQL dump into PasarGuard (exit {exit_code}).",
+            "See mysql client output and DB container logs. "
+            "If the service crashed mid-import, fix that before retrying.",
+        )
+
+    return MysqlImportFailure(
+        "unknown",
+        exit_code,
+        "Failed to import MySQL dump into PasarGuard.",
+        "See output and DB container logs.",
+    )
+
+
+def format_mysql_import_error(
+    failure: MysqlImportFailure,
+    *,
+    output_tail: str = "",
+    diag_tail: str = "",
+) -> str:
+    """Build a single RuntimeError message; keep it readable in the job UI."""
+    parts = [failure.summary, failure.guidance]
+    out = (output_tail or "").strip()
+    if out:
+        # Password-on-CLI warning alone is noise for killed/auth classification.
+        useful = [
+            ln for ln in out.splitlines()
+            if ln.strip()
+            and "using a password on the command line interface can be insecure" not in ln.lower()
+        ]
+        if useful:
+            parts.append("mysql client output:\n" + "\n".join(useful[-40:]))
+        elif failure.kind != "killed":
+            parts.append("mysql client output:\n" + "\n".join(out.splitlines()[-10:]))
+    diag = (diag_tail or "").strip()
+    if diag:
+        parts.append("container diagnostics:\n" + diag[-1200:])
+    return "\n".join(parts)
+
+
+async def compose_service_running(cwd: str, service: str) -> bool | None:
+    """True if up, False if definitely down, None if probe failed (do not abort)."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "compose", "ps", "-q", service,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out_b, _ = await _communicate_timeout(proc, 12)
+    except Exception:
+        return None
+    cid = (out_b or b"").decode("utf-8", errors="replace").strip()
+    if not cid:
+        # Empty ps -q usually means not running; confirm with ps -a before False.
+        try:
+            proc_a = await asyncio.create_subprocess_exec(
+                "docker", "compose", "ps", "-a", "--format", "{{.State}}", service,
+                cwd=cwd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            st_b, _ = await _communicate_timeout(proc_a, 12)
+            state = (st_b or b"").decode("utf-8", errors="replace").strip().lower()
+            if not state:
+                return None
+            if state.startswith("running"):
+                return True
+            return False
+        except Exception:
+            return None
+
+    try:
+        insp = await asyncio.create_subprocess_exec(
+            "docker", "inspect", "-f", "{{.State.Running}}", cid.splitlines()[0],
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        run_b, _ = await _communicate_timeout(insp, 12)
+        val = (run_b or b"").decode("utf-8", errors="replace").strip().lower()
+        if val == "true":
+            return True
+        if val == "false":
+            return False
+        return None
+    except Exception:
+        return None
+
+
+async def compose_service_oom_killed(cwd: str, service: str) -> bool | None:
+    """Best-effort OOMKilled flag for the compose service container."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "compose", "ps", "-a", "-q", service,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out_b, _ = await _communicate_timeout(proc, 12)
+        cid = (out_b or b"").decode("utf-8", errors="replace").strip().splitlines()
+        if not cid:
+            return None
+        insp = await asyncio.create_subprocess_exec(
+            "docker", "inspect", "-f", "{{.State.OOMKilled}}", cid[0],
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        flag_b, _ = await _communicate_timeout(insp, 12)
+        flag = (flag_b or b"").decode("utf-8", errors="replace").strip().lower()
+        if flag == "true":
+            return True
+        if flag == "false":
+            return False
+        return None
+    except Exception:
+        return None
+
+
+async def compose_service_diagnostics(cwd: str, service: str, *, log_tail: int = 60) -> str:
+    """Best-effort status + log snippet for error messages. Never raises."""
+    chunks: list[str] = []
+    try:
+        ps = await asyncio.create_subprocess_exec(
+            "docker", "compose", "ps", "-a", "--format",
+            "{{.Name}} {{.Status}}", service,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        ps_b, _ = await _communicate_timeout(ps, 15)
+        ps_text = (ps_b or b"").decode("utf-8", errors="replace").strip()
+        if ps_text:
+            chunks.append(f"compose ps: {ps_text}")
+    except Exception as exc:
+        chunks.append(f"compose ps: (unavailable: {type(exc).__name__})")
+
+    oom = await compose_service_oom_killed(cwd, service)
+    if oom is True:
+        chunks.append("OOMKilled: true")
+    elif oom is False:
+        chunks.append("OOMKilled: false")
+
+    try:
+        logs = await asyncio.create_subprocess_exec(
+            "docker", "compose", "logs", "--no-color", "--tail", str(log_tail), service,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        log_b, _ = await _communicate_timeout(logs, 20)
+        log_text = (log_b or b"").decode("utf-8", errors="replace").strip()
+        if log_text:
+            chunks.append(log_text[-1000:])
+    except Exception as exc:
+        chunks.append(f"compose logs: (unavailable: {type(exc).__name__})")
+
+    return "\n".join(chunks).strip()

--- a/tests/test_mysql_import_diagnostics.py
+++ b/tests/test_mysql_import_diagnostics.py
@@ -1,0 +1,114 @@
+"""Unit tests for MySQL import failure classification / message formatting."""
+
+from app.services.mysql_import_diagnostics import (
+    classify_mysql_import_failure,
+    format_mysql_import_error,
+)
+
+
+def test_exit_137_is_killed_not_credentials():
+    failure = classify_mysql_import_failure(
+        137,
+        "mysql: [Warning] Using a password on the command line interface can be insecure.",
+    )
+    assert failure.kind == "killed"
+    msg = format_mysql_import_error(
+        failure,
+        output_tail="mysql: [Warning] Using a password on the command line interface can be insecure.",
+    )
+    assert "Check DB credentials" not in msg
+    assert "can be insecure" not in msg
+    low = msg.lower()
+    assert "not" in low and ("password" in low or "credential" in low)
+    assert "137" in msg or "sigkill" in low
+
+
+def test_exit_137_with_container_died_and_oom():
+    failure = classify_mysql_import_failure(
+        137, "", container_died=True, oom_killed=True,
+    )
+    assert failure.kind == "killed"
+    msg = format_mysql_import_error(
+        failure, diag_tail="OOMKilled: true\ncompose ps: mysql Exited",
+    )
+    assert "OOM" in msg
+    assert "container diagnostics:" in msg
+    assert "not a db password problem" in msg.lower()
+
+
+def test_access_denied_is_auth():
+    failure = classify_mysql_import_failure(
+        1, "ERROR 1045 (28000): Access denied for user 'root'@'localhost'",
+    )
+    assert failure.kind == "auth"
+    msg = format_mysql_import_error(
+        failure,
+        output_tail="ERROR 1045 (28000): Access denied for user 'root'@'localhost'",
+    )
+    assert "1045" in msg
+    assert "MYSQL_ROOT_PASSWORD" in msg or "credentials" in msg.lower()
+
+
+def test_sql_syntax_error_classified():
+    failure = classify_mysql_import_failure(
+        1, "ERROR 1064 (42000): You have an error in your SQL syntax",
+    )
+    assert failure.kind == "sql"
+    msg = format_mysql_import_error(
+        failure, output_tail="ERROR 1064 (42000): You have an error",
+    )
+    assert "SQL" in msg
+
+
+def test_connection_refused_is_client_not_sql():
+    failure = classify_mysql_import_failure(
+        1, "ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1'",
+    )
+    assert failure.kind == "client"
+    msg = format_mysql_import_error(
+        failure,
+        output_tail="ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1'",
+    )
+    assert "Can't connect" in msg
+    assert "Check DB credentials" not in msg
+
+
+def test_generic_nonzero_keeps_client_output():
+    failure = classify_mysql_import_failure(1, "Unknown failure from mysql client")
+    assert failure.kind == "client"
+    msg = format_mysql_import_error(
+        failure, output_tail="Unknown failure from mysql client",
+    )
+    assert "Unknown failure from mysql client" in msg
+    assert "Check DB credentials" not in msg
+
+
+def test_sigterm_143_is_killed():
+    failure = classify_mysql_import_failure(143, "")
+    assert failure.kind == "killed"
+
+
+def test_negative_sigkill_code():
+    failure = classify_mysql_import_failure(-9, "")
+    assert failure.kind == "killed"
+
+
+def test_format_includes_guidance_about_retry_recreate():
+    failure = classify_mysql_import_failure(
+        137, "", container_died=True, oom_killed=True,
+    )
+    msg = format_mysql_import_error(failure)
+    assert "recreate" in msg.lower() or "retry" in msg.lower()
+
+
+if __name__ == "__main__":
+    test_exit_137_is_killed_not_credentials()
+    test_exit_137_with_container_died_and_oom()
+    test_access_denied_is_auth()
+    test_sql_syntax_error_classified()
+    test_connection_refused_is_client_not_sql()
+    test_generic_nonzero_keeps_client_output()
+    test_sigterm_143_is_killed()
+    test_negative_sigkill_code()
+    test_format_includes_guidance_about_retry_recreate()
+    print("OK: mysql_import_diagnostics")

--- a/tests/test_mysql_import_diagnostics.py
+++ b/tests/test_mysql_import_diagnostics.py
@@ -1,8 +1,14 @@
 """Unit tests for MySQL import failure classification / message formatting."""
 
+from pathlib import Path
+
 from app.services.mysql_import_diagnostics import (
+    MYSQL_IMPORT_SESSION_PREAMBLE,
+    assess_mysql_import_ram,
     classify_mysql_import_failure,
     format_mysql_import_error,
+    mysql_import_session_preamble_sql,
+    write_mysql_import_stdin_file,
 )
 
 
@@ -101,6 +107,60 @@ def test_format_includes_guidance_about_retry_recreate():
     assert "recreate" in msg.lower() or "retry" in msg.lower()
 
 
+def test_ram_preflight_ok_for_small_dump_with_gb_free():
+    advice = assess_mysql_import_ram(25 * 1024 * 1024, 2 * 1024 * 1024 * 1024)
+    assert advice.level == "ok"
+    assert "ok" in advice.message.lower()
+
+
+def test_ram_preflight_warns_on_very_low_free_ram_but_is_advisory():
+    advice = assess_mysql_import_ram(25 * 1024 * 1024, 100 * 1024 * 1024)
+    assert advice.level == "warn"
+    assert "continuing" in advice.message.lower()
+
+
+def test_ram_preflight_warns_large_dump_vs_free_ram():
+    advice = assess_mysql_import_ram(200 * 1024 * 1024, 400 * 1024 * 1024)
+    assert advice.level == "warn"
+    assert "continuing" in advice.message.lower()
+
+
+def test_ram_preflight_unknown_mem_is_info_not_block():
+    from app.services import mysql_import_diagnostics as mid
+
+    orig = mid.read_mem_available_bytes
+    mid.read_mem_available_bytes = lambda: None
+    try:
+        advice = assess_mysql_import_ram(10 * 1024 * 1024, None)
+    finally:
+        mid.read_mem_available_bytes = orig
+    assert advice.level == "info"
+    assert "unknown" in advice.message.lower()
+    assert "continuing" in advice.message.lower()
+
+
+def test_session_preamble_is_session_only_and_minimal():
+    sql = mysql_import_session_preamble_sql()
+    assert sql == MYSQL_IMPORT_SESSION_PREAMBLE
+    low = sql.lower()
+    assert "session" in low
+    assert "foreign_key_checks=0" in low
+    assert "unique_checks=0" in low
+    assert "global" not in low
+    assert "sql_log_bin" not in low
+    assert "sql_mode" not in low
+
+
+def test_write_mysql_import_stdin_file_streams_preamble(tmp_path: Path):
+    dump = tmp_path / "dump.sql"
+    dump.write_bytes(b"INSERT INTO t VALUES (1);\n")
+    dest = tmp_path / "ready.sql"
+    write_mysql_import_stdin_file(dump, dest)
+    data = dest.read_bytes()
+    assert data.startswith(MYSQL_IMPORT_SESSION_PREAMBLE.encode("utf-8"))
+    assert data.endswith(b"INSERT INTO t VALUES (1);\n")
+
+
 if __name__ == "__main__":
     test_exit_137_is_killed_not_credentials()
     test_exit_137_with_container_died_and_oom()
@@ -111,4 +171,13 @@ if __name__ == "__main__":
     test_sigterm_143_is_killed()
     test_negative_sigkill_code()
     test_format_includes_guidance_about_retry_recreate()
+    test_ram_preflight_ok_for_small_dump_with_gb_free()
+    test_ram_preflight_warns_on_very_low_free_ram_but_is_advisory()
+    test_ram_preflight_warns_large_dump_vs_free_ram()
+    test_ram_preflight_unknown_mem_is_info_not_block()
+    test_session_preamble_is_session_only_and_minimal()
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        test_write_mysql_import_stdin_file_streams_preamble(Path(d))
     print("OK: mysql_import_diagnostics")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Rare Marzban → PasarGuard MySQL import failures with `exit 137` were reported as credential problems. That message is misleading: `137` is `SIGKILL` (container death / OOM / host killer), and the password-on-CLI warning is noise.

This change hardens **diagnostics and safe import helpers** without blocking healthy migrations.

## What changed
1. **Clearer failure messages** for `exit 137` / container death / OOM vs auth vs SQL vs connect
2. **Advisory RAM preflight** (dump size vs free RAM) — logs only, **never aborts**
3. **SESSION-only preamble** before import: `FOREIGN_KEY_CHECKS=0`, `UNIQUE_CHECKS=0`
   - Same connection as the dump (stream-concat file → same `stdin=file` path)
   - No `GLOBAL`, no `sql_mode`, no `sql_log_bin`
   - If the combined file cannot be written → **fallback to plain rewritten dump**
4. Best-effort compose liveness during long imports + diagnostics on failure

## Explicitly not changed
- No INSERT splitting / dump rewriting beyond existing PasarGuard rewrite
- No hard RAM block
- No import timeout
- Import argv (`docker compose exec … mysql …`) unchanged

## Risk controls
- Preflight is advisory only (`ok` / `info` / `warn` + “continuing”)
- SESSION toggles match what mysqldump headers typically set
- Preamble prep failure cannot block migration (fallback)
- Docker probes abort only when service is **definitively** down (`False`), never on `None`

## Test plan
- [x] `pytest tests/test_mysql_import_diagnostics.py tests/test_marzban_migrate_matrix.py` (20 passed)
- [ ] Manual: successful Marzban MySQL→MySQL migration still completes
- [ ] Manual: low-RAM host shows WARNING preflight but still attempts import
- [ ] Manual: if DB container dies mid-import, error shows kill/OOM diagnostics (not credentials)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07a83-1f67-70c5-ba65-31e0585a16ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07a83-1f67-70c5-ba65-31e0585a16ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

