### PR TITLE
fix(wizard): auto-fill DB password from SQLALCHEMY_DATABASE_URL

### DIFF
--- a/app/services/env_migration.py
+++ b/app/services/env_migration.py
@@ -53,11 +53,17 @@ def migration_primary_key(candidates: list[dict], db_type: str | None) -> str | 
     if not candidates:
         return None
     if db_type in ("mysql", "mariadb"):
-        order = ["MYSQL_ROOT_PASSWORD", "MYSQL_PASSWORD", "DB_PASSWORD"]
+        order = [
+            "MYSQL_ROOT_PASSWORD", "MYSQL_PASSWORD", "DB_PASSWORD",
+            "SQLALCHEMY_DATABASE_URL",
+        ]
     elif db_type in ("postgresql", "timescaledb"):
-        order = ["POSTGRES_PASSWORD", "DB_PASSWORD"]
+        order = ["POSTGRES_PASSWORD", "DB_PASSWORD", "SQLALCHEMY_DATABASE_URL"]
     else:
-        order = ["DB_PASSWORD", "MYSQL_ROOT_PASSWORD", "MYSQL_PASSWORD", "POSTGRES_PASSWORD"]
+        order = [
+            "DB_PASSWORD", "MYSQL_ROOT_PASSWORD", "MYSQL_PASSWORD",
+            "POSTGRES_PASSWORD", "SQLALCHEMY_DATABASE_URL",
+        ]
     keys = {c["key"] for c in candidates}
     for key in order:
         if key in keys:
@@ -66,7 +72,12 @@ def migration_primary_key(candidates: list[dict], db_type: str | None) -> str | 
 
 
 def extract_env_password_candidates(text: str, db_type: str | None = None) -> list[dict]:
-    """Return distinct password keys/values found in a panel .env file."""
+    """Return distinct password keys/values found in a panel .env file.
+
+    Named keys (MYSQL_ROOT_PASSWORD / DB_PASSWORD / …) are preferred. When the
+    password only exists inside ``SQLALCHEMY_DATABASE_URL`` (common PasarGuard
+    installs), that URL password is also surfaced so the wizard can auto-fill.
+    """
     if not text:
         return []
 
@@ -80,19 +91,34 @@ def extract_env_password_candidates(text: str, db_type: str | None = None) -> li
 
     seen_vals: set[str] = set()
     candidates: list[dict] = []
-    for key in keys:
-        val = read_env_var(text, key)
+
+    def _add(key: str, val: str | None) -> None:
         if not val:
-            continue
-        dup = val in seen_vals
+            return
+        # Skip identical secrets under a second label — keeps the Confirm UI tidy.
+        if val in seen_vals:
+            return
         seen_vals.add(val)
         candidates.append({
             "key": key,
             "value": val,
             "masked": mask_password(val),
             "quoted_preview": f'"{mask_password(val)}"',
-            "duplicate_value": dup,
+            "duplicate_value": False,
         })
+
+    for key in keys:
+        _add(key, read_env_var(text, key))
+
+    # Compose installer block (DB_PASSWORD) — covered by keys above when the
+    # var exists; kept via read_compose for consistency with db_auth.
+    compose_pwd = read_compose_db_credentials(text).get("password")
+    _add("DB_PASSWORD", compose_pwd)
+
+    url = read_env_var(text, "SQLALCHEMY_DATABASE_URL") or ""
+    if url:
+        url_pwd = parse_sqlalchemy_url(url, text).get("password")
+        _add("SQLALCHEMY_DATABASE_URL", url_pwd)
 
     primary = migration_primary_key(candidates, db_type)
     for c in candidates:
@@ -105,11 +131,17 @@ def pick_primary_env_password(candidates: list[dict], db_type: str | None) -> st
         return None
     order: list[str]
     if db_type in ("mysql", "mariadb"):
-        order = ["MYSQL_ROOT_PASSWORD", "MYSQL_PASSWORD", "DB_PASSWORD"]
+        order = [
+            "MYSQL_ROOT_PASSWORD", "MYSQL_PASSWORD", "DB_PASSWORD",
+            "SQLALCHEMY_DATABASE_URL",
+        ]
     elif db_type in ("postgresql", "timescaledb"):
-        order = ["POSTGRES_PASSWORD", "DB_PASSWORD"]
+        order = ["POSTGRES_PASSWORD", "DB_PASSWORD", "SQLALCHEMY_DATABASE_URL"]
     else:
-        order = ["DB_PASSWORD", "MYSQL_ROOT_PASSWORD", "MYSQL_PASSWORD", "POSTGRES_PASSWORD"]
+        order = [
+            "DB_PASSWORD", "MYSQL_ROOT_PASSWORD", "MYSQL_PASSWORD",
+            "POSTGRES_PASSWORD", "SQLALCHEMY_DATABASE_URL",
+        ]
     by_key = {c["key"]: c["value"] for c in candidates}
     for key in order:
         if key in by_key:

--- a/tests/test_env_migration.py
+++ b/tests/test_env_migration.py
@@ -110,6 +110,45 @@ MYSQL_ROOT_PASSWORD = "rootpass"
     print("OK: password candidates")
 
 
+def test_extract_env_password_candidates_from_sqlalchemy_url_only():
+    """Wizard auto-fill must work when password lives only in the URL."""
+    text = (
+        'SQLALCHEMY_DATABASE_URL = '
+        '"mysql+asyncmy://pasarguard:Secret%40Pass@mysql:3306/pasarguard"\n'
+    )
+    cands = extract_env_password_candidates(text, "mysql")
+    assert len(cands) == 1
+    assert cands[0]["key"] == "SQLALCHEMY_DATABASE_URL"
+    assert cands[0]["value"] == "Secret@Pass"
+    assert cands[0]["used_for_migration"] is True
+    assert pick_primary_env_password(cands, "mysql") == "Secret@Pass"
+    print("OK: password candidates from SQLALCHEMY URL")
+
+
+def test_extract_env_password_candidates_url_dedupes_named_key():
+    text = '''
+MYSQL_ROOT_PASSWORD = "samepass"
+SQLALCHEMY_DATABASE_URL = "mysql+asyncmy://root:samepass@127.0.0.1:3306/pasarguard"
+'''
+    cands = extract_env_password_candidates(text, "mysql")
+    keys = [c["key"] for c in cands]
+    assert keys == ["MYSQL_ROOT_PASSWORD"]
+    assert pick_primary_env_password(cands, "mysql") == "samepass"
+    print("OK: URL password deduped against named key")
+
+
+def test_extract_env_password_candidates_postgres_url_only():
+    text = (
+        'SQLALCHEMY_DATABASE_URL = '
+        '"postgresql+asyncpg://pasarguard:pgsecret@timescaledb:5432/pasarguard"\n'
+    )
+    cands = extract_env_password_candidates(text, "timescaledb")
+    assert len(cands) == 1
+    assert cands[0]["value"] == "pgsecret"
+    assert cands[0]["used_for_migration"] is True
+    print("OK: postgres/timescale URL password candidates")
+
+
 def test_url_replacement_survives_backslashes():
     """Regression: raw dynamic strings (Windows paths, or any password containing a
     backslash) were passed directly as the `repl` argument to re.sub(), which
@@ -147,5 +186,8 @@ if __name__ == "__main__":
     test_mysql_dump_file_rewrite_streams()
     test_read_env_var()
     test_extract_env_password_candidates()
+    test_extract_env_password_candidates_from_sqlalchemy_url_only()
+    test_extract_env_password_candidates_url_dedupes_named_key()
+    test_extract_env_password_candidates_postgres_url_only()
     test_url_replacement_survives_backslashes()
     print("\nAll env migration tests passed.")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Wizard DB password auto-fill only scanned named `.env` keys (`MYSQL_ROOT_PASSWORD`, `DB_PASSWORD`, …). Many PasarGuard installs keep the secret **only** inside `SQLALCHEMY_DATABASE_URL`, so the wizard showed an empty password field.

## Fix
`extract_env_password_candidates()` now also reads the password from `SQLALCHEMY_DATABASE_URL` (URL-decoded), after named keys. If the same secret already exists under a named key, the URL entry is deduped so Confirm UI stays clean.

Named keys still win for `used_for_migration` when present.

## Test plan
- [x] `pytest tests/test_env_migration.py tests/test_wizard_password_logic.py tests/test_db_auth.py` (31 passed)
- [ ] Manual: PasarGuard `.env` with URL-only password → wizard target password field prefilled
- [ ] Manual: `.env` with `MYSQL_ROOT_PASSWORD` + matching URL → still shows root key as migration password

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07a83-1f67-70c5-ba65-31e0585a16ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07a83-1f67-70c5-ba65-31e0585a16ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

