### PR TITLE
fix(wizard): don't stay stuck at 100% — open Result after migrate

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -862,21 +862,25 @@ function updateStepButtons() {
   }
 }
 
-async function goStep(n) {
+async function goStep(n, opts = {}) {
   state.phase = 'migrate';
-  if (n > state.currentStep) {
+  const force = !!(opts && opts.force);
+  // Gate forward navigation — but NEVER re-validate when opening the result
+  // step (6). Post-migrate .env/DB state often fails validate-migration and
+  // previously trapped the UI on step 5 at 100% "Migration completed".
+  if (!force && n > state.currentStep && n < 6) {
     let block = null;
     if (n >= 2) block = canProceedStep1();
     if (!block && n >= 3) block = canProceedStep2();
     if (!block && n >= 4) block = canProceedStep2() || canProceedStep3();
-    if (!block && n >= 5) {
+    if (!block && n === 5) {
       const v = await validateMigrationRequest();
       if (!v.ok) block = tr(v.errors[0], state.lang) || t('block.validationFailed');
     }
     if (block) {
       showStepBlock(state.currentStep, block);
       updateStepButtons();
-      return;
+      return false;
     }
   }
 
@@ -892,6 +896,7 @@ async function goStep(n) {
   if (typeof renderFlowSteps === 'function') renderFlowSteps();
   showStepBlock(n, null);
   updateStepButtons();
+  return true;
 }
 
 async function validateMigrationRequest() {
@@ -1269,8 +1274,27 @@ function connectWebSocket(jobId) {
   let finished = false;
   const terminal = document.getElementById('logTerminal');
 
+  const finishOnce = (ok, payload, errMsg) => {
+    if (finished) return;
+    finished = true;
+    state._migrateWs = null;
+    try {
+      if (ok) void showSuccess(payload);
+      else void showError(errMsg || payload?.error || 'Error', terminal?.textContent || '');
+    } catch (e) {
+      console.error('migrate finish handler failed:', e);
+      void showError(e.message || 'Error', terminal?.textContent || '');
+    }
+  };
+
   ws.onmessage = (ev) => {
-    const msg = JSON.parse(ev.data);
+    let msg;
+    try {
+      msg = JSON.parse(ev.data);
+    } catch (e) {
+      console.error('migrate ws bad json:', e);
+      return;
+    }
     if (msg.type === 'log') {
       terminal.textContent += msg.message + '\n';
       terminal.scrollTop = terminal.scrollHeight;
@@ -1288,12 +1312,15 @@ function connectWebSocket(jobId) {
         document.getElementById('progressText').textContent = msg.progress + '%';
       }
       if (msg.message) document.getElementById('statusMsg').textContent = msg.message;
+      // Safety net: terminal status without a following `done` frame.
+      if (msg.status === 'success' && !msg.result?.error) finishOnce(true, msg.result);
+      else if (msg.status === 'error' || msg.result?.error) {
+        finishOnce(false, msg.result, msg.result?.error || msg.message || 'Error');
+      }
     }
     if (msg.type === 'done') {
-      finished = true;
-      state._migrateWs = null;
-      if (msg.status === 'success' && !msg.result?.error) showSuccess(msg.result);
-      else showError(msg.result?.error || msg.message || 'Error', terminal.textContent);
+      if (msg.status === 'success' && !msg.result?.error) finishOnce(true, msg.result);
+      else finishOnce(false, msg.result, msg.result?.error || msg.message || 'Error');
     }
   };
   ws.onerror = () => { if (!finished) pollStatus(jobId); };
@@ -1335,12 +1362,12 @@ async function pollStatus(jobId) {
       if (data.status === 'success' && !data.result?.error) {
         clearInterval(interval);
         state._migratePollInterval = null;
-        showSuccess(data.result);
+        void showSuccess(data.result);
       }
       if (data.status === 'error' || data.result?.error) {
         clearInterval(interval);
         state._migratePollInterval = null;
-        showError(data.result?.error || data.message, data.logs.join('\n'));
+        void showError(data.result?.error || data.message, data.logs.join('\n'));
       }
     } catch (e) { /* retry */ }
   }, 1500);
@@ -1423,8 +1450,8 @@ function renderPostMigrateSection(result) {
   }).join('');
 }
 
-function showSuccess(result) {
-  goStep(6);
+async function showSuccess(result) {
+  await goStep(6, { force: true });
   document.getElementById('resultSuccess').classList.remove('hidden');
   document.getElementById('resultError').classList.add('hidden');
   document.querySelector('#resultSuccess h2').textContent = t('step6.success');
@@ -1451,9 +1478,10 @@ function showSuccess(result) {
   const accessUrl = (typeof resolveLoginUrl === 'function')
     ? resolveLoginUrl(state.panelAccess || state.systemCheck?.panel_access)
     : (state.panelAccess?.login_url || state.systemCheck?.panel_access?.login_url || '');
+  const hostFallback = (state.serverIp && String(state.serverIp).split(':')[0]) || '127.0.0.1';
   const panelUrl = result?.panel_url
     || accessUrl
-    || `https://${state.serverIp.split(':')[0]}:${port}${dash}`.replace(/([^:]\/)\/+/g, '$1');
+    || `https://${hostFallback}:${port}${dash}`.replace(/([^:]\/)\/+/g, '$1');
   document.getElementById('panelLink').href = panelUrl;
 
   const mode = result?.subscription_mode || state.selectedPanel?.subscription_mode;
@@ -1587,8 +1615,8 @@ function renderRedirectVerifyBox(result) {
   });
 }
 
-function showError(msg, logs) {
-  goStep(6);
+async function showError(msg, logs) {
+  await goStep(6, { force: true });
   document.getElementById('resultError').classList.remove('hidden');
   document.getElementById('resultSuccess').classList.add('hidden');
   document.getElementById('errorMessage').textContent = msg;

--- a/tests/test_wizard_result_step_gate.py
+++ b/tests/test_wizard_result_step_gate.py
@@ -1,0 +1,46 @@
+"""Gate rules for wizard goStep — must not block the result screen after migrate."""
+
+
+def should_revalidate_before_step(current_step: int, next_step: int, *, force: bool = False) -> bool:
+    """Mirror app.js goStep gating.
+
+    Re-validate only when moving forward onto the run step (5).
+    Never re-validate when opening the result step (6): post-migrate
+    .env/DB changes often fail validate-migration and used to trap the UI
+    at 100% on the run screen.
+    """
+    if force:
+        return False
+    if not (next_step > current_step):
+        return False
+    if next_step >= 6:
+        return False
+    return next_step == 5
+
+
+def test_result_step_never_revalidates():
+    assert should_revalidate_before_step(5, 6) is False
+    assert should_revalidate_before_step(5, 6, force=True) is False
+    assert should_revalidate_before_step(4, 6) is False
+
+
+def test_entering_run_step_revalidates():
+    assert should_revalidate_before_step(4, 5) is True
+
+
+def test_force_skips_all_gates():
+    assert should_revalidate_before_step(4, 5, force=True) is False
+    assert should_revalidate_before_step(1, 5, force=True) is False
+
+
+def test_backward_or_same_step_no_revalidate():
+    assert should_revalidate_before_step(5, 5) is False
+    assert should_revalidate_before_step(6, 5) is False
+
+
+if __name__ == "__main__":
+    test_result_step_never_revalidates()
+    test_entering_run_step_revalidates()
+    test_force_skips_all_gates()
+    test_backward_or_same_step_no_revalidate()
+    print("OK: wizard result step gate")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After a successful migration the wizard could stay on the run screen at **100%** with `Migration completed successfully!` and never open the Result step.

## Root cause
`goStep(6)` re-ran `/api/validate-migration` because `n >= 5`. Post-migrate `.env` / DB state often fails that check, so navigation aborted while progress/status already showed success.

## Fix
1. Only re-validate when entering the **run** step (`n === 5`); never when opening Result (`n >= 6`)
2. `showSuccess` / `showError` use `goStep(6, { force: true })`
3. WebSocket finishes once on terminal `status` or `done` (no double-open; safer if `done` is dropped)
4. Guard `state.serverIp` when building panel URL fallback

## Test plan
- [x] `pytest tests/test_wizard_result_step_gate.py`
- [ ] Manual: Marzban migrate to 100% → Result step opens with success panel

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07a83-1f67-70c5-ba65-31e0585a16ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07a83-1f67-70c5-ba65-31e0585a16ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

