### PR TITLE
fix(mysql): strip GTID/SQL_LOG_BIN for Marzban migrate and PasarGuard restore

### DIFF
--- a/app/services/env_migration.py
+++ b/app/services/env_migration.py
@@ -1217,8 +1217,50 @@ def transform_xray_config(text: str) -> str:
     return text.replace("/var/lib/marzban", "/var/lib/pasarguard").replace("/opt/marzban", "/opt/pasarguard")
 
 
+# mysqldump replication preamble — breaks MariaDB (GTID_PURGED) and non-SUPER restores
+# (SQL_LOG_BIN needs BINLOG ADMIN). Safe to strip: data rows do not depend on these SETs.
+_MYSQL_DUMP_REPLICATION_PREAMBLE_RE = re.compile(
+    r"(?is)^(?:/\*![\d\s]*\*/\s*)?"
+    r"SET\s+(?:"
+    r"@@(?:GLOBAL|SESSION)\.(?:GTID_PURGED|GTID_EXECUTED|SQL_LOG_BIN)"
+    r"|@MYSQLDUMP_TEMP_LOG_BIN"
+    r")\b"
+)
+
+
+def is_mysql_dump_replication_preamble(line: str) -> bool:
+    """True for mysqldump GTID / SQL_LOG_BIN session lines (not table data)."""
+    body = (line or "").strip()
+    if not body or body.startswith("--") or body.startswith("#"):
+        return False
+    # Conditional comments wrapping SET: /*!80000 SET ... */
+    if body.startswith("/*!") and "SET" in body.upper():
+        inner = re.sub(r"^/\*!\d+\s*", "", body)
+        inner = re.sub(r"\*/\s*$", "", inner).strip()
+        body = inner or body
+    return bool(_MYSQL_DUMP_REPLICATION_PREAMBLE_RE.match(body))
+
+
+def sanitize_mysql_dump_line_for_import(line: str) -> tuple[str, bool]:
+    """Neutralize one dump line for MySQL↔MariaDB import.
+
+    Returns ``(output_line, changed)``. Replication preamble becomes a SQL comment
+    so import continues; all other lines are unchanged.
+    """
+    if not is_mysql_dump_replication_preamble(line):
+        return line, False
+    body = line.strip().rstrip(";")
+    preview = body if len(body) <= 120 else body[:117] + "..."
+    nl = "\n" if line.endswith("\n") else ("\r\n" if line.endswith("\r\n") else "\n")
+    return f"-- pgclockmg-stripped: {preview}{nl}", True
+
+
 def fix_mysql_dump_line_for_pasarguard(line: str) -> str:
-    """Rewrite one dump line: CREATE/USE db name, then safe marzban→pasarguard."""
+    """Rewrite one dump line: strip unsafe mysqldump preamble, then db rename."""
+    line, _ = sanitize_mysql_dump_line_for_import(line)
+    # Do not rename inside our strip comments.
+    if line.lstrip().startswith("-- pgclockmg-stripped:"):
+        return line
     line = re.sub(r"(?i)^(CREATE DATABASE.*)\bmarzban\b", r"\1pasarguard", line)
     line = re.sub(r"(?i)^(USE )\bmarzban\b", r"\1pasarguard", line)
     return line.replace("marzban", "pasarguard")
@@ -1234,10 +1276,43 @@ def fix_mysql_dump_for_pasarguard(sql_text: str) -> str:
     )
 
 
+def rewrite_mysql_dump_file_for_import(src: Path, dest: Path) -> int:
+    """Stream-sanitize mysqldump GTID/SQL_LOG_BIN preamble for safe import.
+
+    Used by PasarGuard backup restore (no Marzban rename). Returns changed lines.
+    """
+    src = Path(src)
+    dest = Path(dest)
+    if not src.exists():
+        raise RuntimeError(f"MySQL dump not found: {src}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    changed = 0
+    tmp = dest if dest.resolve() != src.resolve() else dest.with_suffix(dest.suffix + ".sanitizing")
+    try:
+        with src.open("r", encoding="utf-8", errors="ignore") as fin, tmp.open(
+            "w", encoding="utf-8", newline=""
+        ) as fout:
+            for line in fin:
+                new_line, did = sanitize_mysql_dump_line_for_import(line)
+                if did:
+                    changed += 1
+                fout.write(new_line)
+        if tmp != dest:
+            tmp.replace(dest)
+    finally:
+        if tmp != dest and tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+    return changed
+
+
 def rewrite_mysql_dump_file_for_pasarguard(src: Path, dest: Path) -> int:
     """Stream-rewrite a dump file without loading the whole SQL into memory.
 
     Returns the number of lines that changed. Safe for multi-hundred-MB dumps.
+    Includes GTID/SQL_LOG_BIN sanitization + marzban→pasarguard rename.
     """
     src = Path(src)
     dest = Path(dest)

--- a/app/services/native_migration/sql_staging.py
+++ b/app/services/native_migration/sql_staging.py
@@ -78,9 +78,12 @@ def prepare_mysql_dump_for_staging(sql_text: str, staging_db: str) -> tuple[str,
     Importing that into ``pgmig_*`` still switches context, so tables land in
     ``pasarguard`` while Phase1 reads ``pgmig_*`` → 0 rows and aborted convert.
     Strip CREATE/DROP/USE database redirects; the client already selects staging_db.
+    Also neutralize mysqldump GTID/SQL_LOG_BIN preamble.
 
     Returns (rewritten_sql, number_of_stripped_lines).
     """
+    from app.services.env_migration import sanitize_mysql_dump_line_for_import
+
     _safe_mysql_ident(staging_db)  # validate only
     out: list[str] = []
     stripped = 0
@@ -96,7 +99,10 @@ def prepare_mysql_dump_for_staging(sql_text: str, staging_db: str) -> tuple[str,
         ):
             stripped += 1
             continue
-        out.append(line)
+        new_line, did = sanitize_mysql_dump_line_for_import(line)
+        if did:
+            stripped += 1
+        out.append(new_line)
     return "".join(out), stripped
 
 
@@ -105,7 +111,10 @@ def write_mysql_dump_for_staging(dump_path: Path, staging_db: str) -> tuple[Path
 
     Streams line-by-line — large Marzban dumps (hundreds of MB) must not be
     loaded entirely into memory via ``read_text()``.
+    Also neutralizes mysqldump GTID/SQL_LOG_BIN preamble for MariaDB imports.
     """
+    from app.services.env_migration import sanitize_mysql_dump_line_for_import
+
     dump_path = Path(dump_path)
     _safe_mysql_ident(staging_db)  # validate only
     if not dump_path.exists():
@@ -128,7 +137,10 @@ def write_mysql_dump_for_staging(dump_path: Path, staging_db: str) -> tuple[Path
             ):
                 stripped += 1
                 continue
-            fout.write(line)
+            new_line, did = sanitize_mysql_dump_line_for_import(line)
+            if did:
+                stripped += 1
+            fout.write(new_line)
 
     if stripped == 0:
         # No redirects stripped — reuse original and drop the identical copy.

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -4128,6 +4128,24 @@ async def _restore_mysql(
     await _compose(job, "up", "-d", svc, timeout=180)
     await asyncio.sleep(5)
 
+    # Strip mysqldump GTID/SQL_LOG_BIN preamble (MySQL 8 → MariaDB / non-SUPER).
+    # Does not rename schemas — PasarGuard restore only.
+    from app.services.env_migration import rewrite_mysql_dump_file_for_import
+
+    import_dump = dump
+    sanitized = dump.parent / f"{dump.name}.import-safe.sql"
+    try:
+        stripped = rewrite_mysql_dump_file_for_import(dump, sanitized)
+        if stripped:
+            job.log(
+                f"Sanitized {stripped} mysqldump preamble line(s) "
+                f"(GTID_PURGED / SQL_LOG_BIN) before MySQL/MariaDB restore"
+            )
+            import_dump = sanitized
+    except OSError as exc:
+        job.log(f"Dump sanitize skipped ({exc}) — importing original dump")
+        import_dump = dump
+
     attempts = []
     if root_pw:
         attempts.append(("root", root_pw, None))
@@ -4143,6 +4161,7 @@ async def _restore_mysql(
         attempts.append((db_user, c_pass, db_name))
 
     last_err = ""
+    best_err = ""
     for user, pwd, db in attempts:
         for mysql_cmd in client_bins:
             cmd = [
@@ -4152,7 +4171,7 @@ async def _restore_mysql(
             if db:
                 cmd.append(db)
             job.log(f"Trying MySQL restore as {user}" + (f"/{db}" if db else "") + f" ({mysql_cmd})")
-            with open(dump, "rb") as dump_fh:
+            with open(import_dump, "rb") as dump_fh:
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     cwd=str(PASARGUARD_DIR),
@@ -4164,10 +4183,28 @@ async def _restore_mysql(
             out = (out_b or b"").decode("utf-8", errors="replace")
             if proc.returncode == 0:
                 job.log("MySQL/MariaDB dump restored")
+                try:
+                    if sanitized.exists() and sanitized.resolve() != dump.resolve():
+                        sanitized.unlink()
+                except OSError:
+                    pass
                 return
             last_err = out[-1500:]
             job.log(f"Attempt failed: {last_err[:300]}")
-    raise RuntimeError(f"MySQL restore failed after password attempts:\n{last_err}")
+            # Prefer real SQL errors over "mysql binary missing" noise for the final raise.
+            low = out.lower()
+            if "error " in low or "access denied" in low:
+                best_err = last_err
+            elif not best_err:
+                best_err = last_err
+    try:
+        if sanitized.exists() and sanitized.resolve() != dump.resolve():
+            sanitized.unlink()
+    except OSError:
+        pass
+    raise RuntimeError(
+        f"MySQL restore failed after password attempts:\n{best_err or last_err}"
+    )
 
 
 async def _restore_postgres(

--- a/tests/test_env_migration.py
+++ b/tests/test_env_migration.py
@@ -62,6 +62,65 @@ def test_mysql_dump_fix():
     print("OK: mysql dump fix")
 
 
+def test_mysql_dump_strips_gtid_and_sql_log_bin():
+    from app.services.env_migration import (
+        fix_mysql_dump_for_pasarguard,
+        rewrite_mysql_dump_file_for_import,
+        sanitize_mysql_dump_line_for_import,
+    )
+
+    preamble = (
+        "SET @MYSQLDUMP_TEMP_LOG_BIN = @@SESSION.SQL_LOG_BIN;\n"
+        "SET @@SESSION.SQL_LOG_BIN= 0;\n"
+        "SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ '';\n"
+        "SET @@SESSION.SQL_LOG_BIN = @MYSQLDUMP_TEMP_LOG_BIN;\n"
+        "CREATE DATABASE marzban;\n"
+        "USE marzban;\n"
+        "INSERT INTO users VALUES (1);\n"
+        "SET foreign_key_checks=0;\n"
+    )
+    out = fix_mysql_dump_for_pasarguard(preamble)
+    assert "GTID_PURGED" not in out or "pgclockmg-stripped" in out
+    assert "CREATE DATABASE pasarguard" in out
+    assert "INSERT INTO users VALUES (1);" in out
+    assert "SET foreign_key_checks=0;" in out
+    # Stripped lines become comments — executable SET GTID/SQL_LOG_BIN gone
+    for line in out.splitlines():
+        body = line.strip()
+        if body.startswith("--"):
+            continue
+        assert "GTID_PURGED" not in body
+        assert "SQL_LOG_BIN" not in body
+        assert "MYSQLDUMP_TEMP_LOG_BIN" not in body
+
+    # PasarGuard restore path: sanitize only (no marzban rename)
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(td) / "dump.sql"
+        dest = Path(td) / "safe.sql"
+        src.write_text(preamble, encoding="utf-8")
+        n = rewrite_mysql_dump_file_for_import(src, dest)
+        assert n >= 4
+        text = dest.read_text(encoding="utf-8")
+        assert "CREATE DATABASE marzban" in text  # rename not applied
+        assert "INSERT INTO users VALUES (1);" in text
+        for line in text.splitlines():
+            body = line.strip()
+            if body.startswith("--"):
+                continue
+            assert "GTID_PURGED" not in body
+            assert "SQL_LOG_BIN" not in body
+
+    line, changed = sanitize_mysql_dump_line_for_import(
+        "SET @@GLOBAL.GTID_PURGED=/*!80000 '+'*/ '';\n"
+    )
+    assert changed is True
+    assert line.startswith("-- pgclockmg-stripped:")
+    print("OK: mysql dump strips GTID/SQL_LOG_BIN")
+
+
 def test_mysql_dump_file_rewrite_streams(tmp_path=None):
     """File rewrite must match in-memory fix and support in-place rewrite."""
     import tempfile
@@ -183,6 +242,7 @@ if __name__ == "__main__":
     test_mysql_env_uses_root_password()
     test_compose_transform()
     test_mysql_dump_fix()
+    test_mysql_dump_strips_gtid_and_sql_log_bin()
     test_mysql_dump_file_rewrite_streams()
     test_read_env_var()
     test_extract_env_password_candidates()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
MySQL 8 `mysqldump` backups fail on MariaDB / non-SUPER restores because of replication preamble:

- `SET @@GLOBAL.GTID_PURGED=...` → `ERROR 1193` on MariaDB
- `SET @@SESSION.SQL_LOG_BIN=0` → `ERROR 1227` without BINLOG ADMIN

The final error was often misleading (`mysql` binary missing on MariaDB images).

## Fix
Shared stream sanitizer comments out only those preamble `SET` lines (data untouched):

1. **Marzban migrate** — via existing `rewrite_mysql_dump_file_for_pasarguard`
2. **Staging / cross-DB MySQL import** — `write_mysql_dump_for_staging` / `prepare_mysql_dump_for_staging`
3. **PasarGuard backup restore** — `_restore_mysql` writes `.import-safe.sql` before import (no schema rename)

Also prefer real SQL errors over `mysql: not found` in the final restore exception.

## Safety
- SQLite / Postgres / Timescale paths unchanged
- Only matches `SET @@…GTID_*` / `SQL_LOG_BIN` / `@MYSQLDUMP_TEMP_LOG_BIN`
- Leaves `foreign_key_checks` and table data alone

## Test plan
- [x] `pytest tests/test_env_migration.py tests/test_marzban_migrate_matrix.py tests/test_sql_staging.py` (32 passed)
- [ ] Manual: restore MySQL8 dump into MariaDB PasarGuard
- [ ] Manual: Marzban MySQL → PasarGuard MariaDB migrate

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07a83-1f67-70c5-ba65-31e0585a16ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07a83-1f67-70c5-ba65-31e0585a16ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

