### PR TITLE
Telegram split parts: keep .zip at end of filename

### DIFF
--- a/app/services/backup_telegram.py
+++ b/app/services/backup_telegram.py
@@ -28,6 +28,20 @@ TELEGRAM_CAPTION_MAX = 1024
 TELEGRAM_TEXT_MAX = 4000
 
 
+def telegram_part_filename(path: Path, part_index: int, parts: int) -> str:
+    """Build a Telegram part name that keeps the real archive extension last.
+
+    Single part: ``backup.zip``
+    Multi part:  ``backup-1-2.zip``, ``backup-2-2.zip``  (reads as 1/2, 2/2)
+    Slash is avoided so downloads stay valid on Windows/Linux.
+    """
+    if parts <= 1:
+        return path.name
+    stem = path.stem or path.name
+    suffix = path.suffix or ".zip"
+    return f"{stem}-{part_index}-{parts}{suffix}"
+
+
 def _proxy_url(tg: dict) -> str | None:
     if not tg.get("proxy_enabled"):
         return None
@@ -277,7 +291,7 @@ def _send_document_parts(
             chunk = fh.read(max_part)
             if not chunk:
                 break
-            part_name = path.name if parts == 1 else f"{path.name}.{idx + 1:03d}-of-{parts:03d}"
+            part_name = telegram_part_filename(path, idx + 1, parts)
             if parts == 1:
                 caption = full_caption
             elif idx == 0:

--- a/tests/test_backup_system.py
+++ b/tests/test_backup_system.py
@@ -62,8 +62,15 @@ def test_settings_mask_secrets(tmp_path, monkeypatch):
 
 
 def test_telegram_caption_and_chunk_math():
-    from app.services.backup_telegram import clip_caption, format_caption, human_size, resolve_admin_chat_id
+    from app.services.backup_telegram import (
+        clip_caption,
+        format_caption,
+        human_size,
+        resolve_admin_chat_id,
+        telegram_part_filename,
+    )
     import math
+    from pathlib import Path
     from app.config import TELEGRAM_BOT_MAX_BYTES
 
     text = format_caption(
@@ -81,6 +88,11 @@ def test_telegram_caption_and_chunk_math():
     clipped = clip_caption("x" * 2000, 1024)
     assert len(clipped) == 1024
     assert clipped.endswith("…")
+    p = Path("pgclockmg-20260908-020711.zip")
+    assert telegram_part_filename(p, 1, 1) == "pgclockmg-20260908-020711.zip"
+    assert telegram_part_filename(p, 1, 2) == "pgclockmg-20260908-020711-1-2.zip"
+    assert telegram_part_filename(p, 2, 2) == "pgclockmg-20260908-020711-2-2.zip"
+    assert telegram_part_filename(p, 1, 2).endswith(".zip")
     print("OK: telegram caption + chunk sizing")
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change
Telegram multi-part backup filenames no longer append after `.zip`.

**Before:** `pgclockmg-….zip.001-of-002`  
**After:** `pgclockmg-…-1-2.zip` / `pgclockmg-…-2-2.zip`

Keeps the real archive extension last (clients treat it as zip). Part index is `1-2` meaning 1/2 (literal `/` avoided so downloads stay valid on Windows/Linux). Single-part uploads stay `….zip`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04f50-fff3-7900-82d7-f1df60610a7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04f50-fff3-7900-82d7-f1df60610a7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

