### PR TITLE
fix: restore ImportError for read_env_text + alembic duplicate heal

### DIFF
--- a/app/services/pasarguard_ops.py
+++ b/app/services/pasarguard_ops.py
@@ -659,6 +659,7 @@ async def _try_heal_pgbouncer_stale(migrator) -> bool:
 
 async def _try_heal_nats_multiworker(migrator, logs: str) -> bool:
     """Align NATS env and bring NATS up before panel workers retry."""
+    from app.services.db_auth import read_env_text
     from app.services.multiworker_stack import (
         NATS_SERVICE,
         align_nats_env_for_compose,
@@ -666,7 +667,6 @@ async def _try_heal_nats_multiworker(migrator, logs: str) -> bool:
         detect_multiworker_stack,
         ensure_nats_ready,
     )
-    from app.services.env_migration import read_env_text
 
     stack = detect_multiworker_stack()
     workers = int(stack.get("uvicorn_workers") or 1)
@@ -697,6 +697,49 @@ async def _try_heal_nats_multiworker(migrator, logs: str) -> bool:
         return new_env != env
     except Exception as e:
         migrator.job.log(f"NATS multi-worker heal note: {e}")
+        return False
+
+
+async def _try_heal_alembic_duplicate_from_logs(migrator, logs: str) -> bool:
+    """If panel alembic failed because objects already exist, align alembic_version."""
+    text = logs or ""
+    if not _is_duplicate_schema_error(text):
+        return False
+
+    low = text.lower()
+    # Gate: only heal real panel migration failures, not incidental restore noise
+    # like "CREATE ROLE … already exists".
+    migration_fail = (
+        "database migrations failed" in low
+        or "duplicatecolumn" in low
+        or (
+            ("table" in low or "relation" in low or "column" in low)
+            and "already exists" in low
+            and any(
+                marker in low
+                for marker in (
+                    "sqlalchemy",
+                    "operationalerror",
+                    "asyncmy",
+                    "asyncpg",
+                    "programmingerror",
+                )
+            )
+        )
+    )
+    if not migration_fail:
+        return False
+
+    target_db = (migrator.params or {}).get("target_db")
+    if target_db not in ("postgresql", "timescaledb", "mysql", "mariadb", "sqlite"):
+        return False
+    try:
+        migrator.job.log(
+            "Alembic duplicate schema in panel logs — healing alembic_version…"
+        )
+        return await _heal_alembic_duplicate_schema(migrator, target_db, text)
+    except Exception as e:
+        migrator.job.log(f"Alembic duplicate-schema heal note: {e}")
         return False
 
 
@@ -1240,6 +1283,13 @@ async def verify_pasarguard_healthy(migrator, max_wait: int = 180) -> None:
                     migrator.job.log(
                         f"Panel error detected ({hit}) — Marzban pre-boot heal applied, "
                         "recreating panel…"
+                    )
+                # Schema already applied but alembic_version lags (e.g. Table already exists)
+                elif await _try_heal_alembic_duplicate_from_logs(migrator, out):
+                    healed = True
+                    migrator.job.log(
+                        f"Panel error detected ({hit}) — alembic_version healed for "
+                        "duplicate schema, recreating panel…"
                     )
                 elif await _try_heal_nats_multiworker(migrator, out):
                     healed = True

--- a/tests/test_migration_logic.py
+++ b/tests/test_migration_logic.py
@@ -216,6 +216,13 @@ def test_alembic_duplicate_heal_helpers():
     assert _is_duplicate_schema_error("column already exists") is True
     assert _is_duplicate_schema_error("ok") is False
 
+    mysql_1050 = (
+        'sqlalchemy.exc.OperationalError: (asyncmy.errors.OperationalError) '
+        '(1050, "Table \'api_keys\' already exists")\n'
+        "ERROR: Database migrations failed"
+    )
+    assert _is_duplicate_schema_error(mysql_1050) is True
+
     missing = (
         "ERROR [alembic.util.messaging] Can't locate revision identified by '5b41f7d2e9a1'"
     )
@@ -223,6 +230,53 @@ def test_alembic_duplicate_heal_helpers():
     assert _is_missing_revision_error(missing) is True
     assert _is_missing_revision_error(log) is False
     print("OK: alembic duplicate/missing revision heal helpers")
+
+
+def test_try_heal_alembic_duplicate_from_logs_mysql_1050():
+    """Panel MySQL 1050 (table already exists) should trigger alembic_version heal."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from app.services.pasarguard_ops import _try_heal_alembic_duplicate_from_logs
+    from app.services.migrators.base import MigrationJob
+
+    logs = (
+        'pasarguard-1 | sqlalchemy.exc.OperationalError: '
+        '(asyncmy.errors.OperationalError) (1050, "Table \'api_keys\' already exists")\n'
+        "pasarguard-1 | ERROR: Database migrations failed"
+    )
+
+    class _Mig:
+        def __init__(self):
+            self.job = MigrationJob(job_id="dup-schema")
+            self.params = {"target_db": "mysql"}
+
+    mig = _Mig()
+
+    with patch(
+        "app.services.pasarguard_ops._heal_alembic_duplicate_schema",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as heal:
+        ok = asyncio.run(_try_heal_alembic_duplicate_from_logs(mig, logs))
+    assert ok is True
+    heal.assert_awaited_once()
+    assert heal.await_args.args[1] == "mysql"
+
+    # Benign CREATE ROLE noise must not stamp
+    with patch(
+        "app.services.pasarguard_ops._heal_alembic_duplicate_schema",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as heal2:
+        ok2 = asyncio.run(
+            _try_heal_alembic_duplicate_from_logs(
+                mig, 'ERROR: role "pasarguard" already exists'
+            )
+        )
+    assert ok2 is False
+    heal2.assert_not_awaited()
+    print("OK: alembic duplicate heal from panel MySQL 1050 logs")
 
 
 def test_alembic_still_running_helpers():
@@ -598,6 +652,7 @@ if __name__ == "__main__":
     test_parse_sqlalchemy_urls()
     test_read_sqlite_alembic_version()
     test_alembic_duplicate_heal_helpers()
+    test_try_heal_alembic_duplicate_from_logs_mysql_1050()
     test_alembic_still_running_helpers()
     test_write_alembic_version_on_sqlite_conn()
     test_heal_unknown_refuses_live_mysql()

--- a/tests/test_multiworker_restore.py
+++ b/tests/test_multiworker_restore.py
@@ -259,6 +259,35 @@ def test_extract_failure_snippet_includes_exception_line():
     print("OK: failure snippet includes exception line")
 
 
+def test_try_heal_nats_imports_read_env_text_from_db_auth():
+    """Regression: read_env_text lives in db_auth, not env_migration."""
+    import asyncio
+    import inspect
+
+    from app.services.pasarguard_ops import _try_heal_nats_multiworker
+    from app.services.migrators.base import MigrationJob
+
+    src = inspect.getsource(_try_heal_nats_multiworker)
+    assert "from app.services.db_auth import read_env_text" in src
+    assert "from app.services.env_migration import read_env_text" not in src
+
+    class _Mig:
+        def __init__(self):
+            self.job = MigrationJob(job_id="nats-import")
+            self.params = {"target_db": "mysql"}
+
+    with patch.object(mws, "detect_multiworker_stack", return_value={
+        "uvicorn_workers": 1,
+        "uses_nats": False,
+        "orchestrate": False,
+    }):
+        result = asyncio.run(
+            _try_heal_nats_multiworker(_Mig(), "Database migrations failed")
+        )
+    assert result is False
+    print("OK: NATS heal imports read_env_text from db_auth (no ImportError)")
+
+
 if __name__ == "__main__":
     test_detect_single_worker_stack()
     test_detect_multiworker_with_nats()
@@ -273,4 +302,5 @@ if __name__ == "__main__":
     test_pgbouncer_env_mismatch_detects_stale_credentials()
     test_extract_failure_snippet_includes_root_before_startup_failed()
     test_extract_failure_snippet_includes_exception_line()
+    test_try_heal_nats_imports_read_env_text_from_db_auth()
     print("\nAll multiworker restore tests passed")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Restore was failing with:
```
cannot import name 'read_env_text' from 'app.services.env_migration'
```
and panel logs also showed MySQL `1050 Table 'api_keys' already exists` / `Database migrations failed`.

## Changes
- **Import fix:** `_try_heal_nats_multiworker` now imports `read_env_text` from `app.services.db_auth` (where it is defined), matching the sibling DB-auth heal path.
- **Alembic heal:** When panel logs show a real duplicate-schema migration failure (e.g. MySQL 1050 / DuplicateColumn), auto-align `alembic_version` via the existing `_heal_alembic_duplicate_schema` helper before recreating the panel. Benign noise like `CREATE ROLE … already exists` is ignored.
- **Tests:** Regression coverage for the import and MySQL 1050 heal gate.

## Test plan
- [x] `python3 tests/test_multiworker_restore.py`
- [x] Isolated unit checks for `_try_heal_alembic_duplicate_from_logs` (MySQL 1050 → heal, role already exists → no heal)
- [ ] Re-run restore on a MySQL target where schema objects already exist / alembic_version is stale

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

