### PR TITLE
fix: heal orphan FK rows on PG/MySQL restore

### DIFF
--- a/app/services/marzban_preboot_heal.py
+++ b/app/services/marzban_preboot_heal.py
@@ -30,12 +30,23 @@ def _ident(name: str) -> str:
 
 
 # Matches PasarGuard panel migration orphan cleanup (delete side).
+# Soft child tables (reminders / hwids / associations) are included so dirty
+# PasarGuard dumps with leftover rows after soft-skipped users do not abort
+# same-engine PG restore (ON_ERROR_STOP) or alembic FK rebuilds.
 ORPHAN_DELETE_SPECS: tuple[tuple[str, str, str, str], ...] = (
     ("node_usages", "node_id", "nodes", "id"),
     ("node_user_usages", "node_id", "nodes", "id"),
     ("node_user_usages", "user_id", "users", "id"),
     ("node_usage_reset_logs", "node_id", "nodes", "id"),
     ("next_plans", "user_id", "users", "id"),
+    ("notification_reminders", "user_id", "users", "id"),
+    ("admin_notification_reminders", "admin_id", "admins", "id"),
+    ("user_hwids", "user_id", "users", "id"),
+    ("user_subscription_updates", "user_id", "users", "id"),
+    ("users_groups_association", "user_id", "users", "id"),
+    ("users_groups_association", "group_id", "groups", "id"),
+    ("exclude_inbounds_association", "user_id", "users", "id"),
+    ("exclude_inbounds_association", "inbound_id", "inbounds", "id"),
 )
 
 # SET NULL style refs (parent missing → null child column).
@@ -80,7 +91,7 @@ def orphan_null_sql(child: str, child_col: str, parent: str, parent_col: str = "
 
 
 def logs_indicate_orphan_fk(logs: str) -> bool:
-    """True when panel/alembic logs show an orphan FK failure we can heal."""
+    """True when panel/alembic/restore logs show an orphan FK failure we can heal."""
     low = (logs or "").lower()
     if not any(
         s in low
@@ -90,6 +101,7 @@ def logs_indicate_orphan_fk(logs: str) -> bool:
             "violates foreign key",
             "1452",
             "integrityerror",
+            "is not present in table",
         )
     ):
         return False
@@ -100,12 +112,142 @@ def logs_indicate_orphan_fk(logs: str) -> bool:
             "node_user_usages",
             "node_usage_reset",
             "next_plans",
+            "notification_reminders",
+            "admin_notification_reminders",
+            "user_hwids",
+            "user_subscription_updates",
+            "users_groups_association",
+            "exclude_inbounds_association",
             "node_id",
             "inbound_tag",
+            "user_id",
+            "admin_id",
             "references nodes",
             "references users",
+            "references admins",
+            "references groups",
+            "references inbounds",
         )
     )
+
+
+def orphan_fk_defer_prefix_sql() -> str:
+    """Best-effort PG session preamble so dirty dumps can load before orphan heal.
+
+    ``session_replication_role=replica`` skips FK triggers (superuser). When the
+    role lacks privilege the DO block only raises a NOTICE and import continues;
+    a subsequent orphan heal still cleans whatever landed, and a hard FK abort
+    still surfaces for the caller to retry with a privileged role if needed.
+    """
+    return (
+        "-- PGClockMG: defer FK checks for orphan-tolerant dump import\n"
+        "DO $pgclockmg_fk$ BEGIN\n"
+        "  PERFORM set_config('session_replication_role', 'replica', false);\n"
+        "EXCEPTION\n"
+        "  WHEN insufficient_privilege THEN\n"
+        "    RAISE NOTICE 'session_replication_role=replica denied (non-superuser)';\n"
+        "  WHEN OTHERS THEN\n"
+        "    RAISE NOTICE 'session_replication_role=replica skipped: %', SQLERRM;\n"
+        "END $pgclockmg_fk$;\n"
+    )
+
+
+def orphan_fk_defer_suffix_sql() -> str:
+    return (
+        "\nDO $pgclockmg_fk$ BEGIN\n"
+        "  PERFORM set_config('session_replication_role', 'origin', false);\n"
+        "EXCEPTION WHEN OTHERS THEN\n"
+        "  NULL;\n"
+        "END $pgclockmg_fk$;\n"
+    )
+
+
+def write_orphan_tolerant_pg_dump(src: Path, dest: Path) -> Path:
+    """Copy ``src`` to ``dest`` wrapped with FK-defer preamble/epilogue."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with open(src, "rb") as inf, open(dest, "wb") as outf:
+        outf.write(orphan_fk_defer_prefix_sql().encode("utf-8"))
+        while True:
+            chunk = inf.read(1024 * 1024)
+            if not chunk:
+                break
+            outf.write(chunk)
+        outf.write(orphan_fk_defer_suffix_sql().encode("utf-8"))
+    return dest
+
+
+def mysql_fk_checks_off_sql() -> str:
+    return "SET FOREIGN_KEY_CHECKS=0;\n"
+
+
+def mysql_fk_checks_on_sql() -> str:
+    return "\nSET FOREIGN_KEY_CHECKS=1;\n"
+
+
+def write_orphan_tolerant_mysql_dump(src: Path, dest: Path) -> Path:
+    """Copy ``src`` to ``dest`` with FOREIGN_KEY_CHECKS toggled around the dump."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with open(src, "rb") as inf, open(dest, "wb") as outf:
+        outf.write(mysql_fk_checks_off_sql().encode("utf-8"))
+        while True:
+            chunk = inf.read(1024 * 1024)
+            if not chunk:
+                break
+            outf.write(chunk)
+        outf.write(mysql_fk_checks_on_sql().encode("utf-8"))
+    return dest
+
+
+def orphan_cleanup_sql_script() -> str:
+    """Idempotent DELETE/UPDATE script for all orphan specs (PostgreSQL)."""
+    parts: list[str] = [
+        "-- PGClockMG: remove orphan FK rows after dump import (no-op when clean)\n"
+    ]
+    for child, child_col, parent, parent_col in ORPHAN_DELETE_SPECS:
+        c, cc, p, pc = map(_ident, (child, child_col, parent, parent_col))
+        parts.append(
+            f"DO $pgclockmg_orphan$ BEGIN\n"
+            f"  IF to_regclass('public.{c}') IS NOT NULL\n"
+            f"     AND to_regclass('public.{p}') IS NOT NULL\n"
+            f"     AND EXISTS (\n"
+            f"       SELECT 1 FROM information_schema.columns\n"
+            f"       WHERE table_schema='public' AND table_name='{c}'\n"
+            f"         AND column_name='{cc}'\n"
+            f"     ) THEN\n"
+            f"    {orphan_delete_sql(c, cc, p, pc)};\n"
+            f"  END IF;\n"
+            f"EXCEPTION WHEN OTHERS THEN\n"
+            f"  RAISE NOTICE 'orphan delete skipped on {c}.{cc}: %', SQLERRM;\n"
+            f"END $pgclockmg_orphan$;\n"
+        )
+    for child, child_col, parent, parent_col in ORPHAN_NULL_SPECS:
+        c, cc, p, pc = map(_ident, (child, child_col, parent, parent_col))
+        parts.append(
+            f"DO $pgclockmg_orphan$ BEGIN\n"
+            f"  IF EXISTS (\n"
+            f"       SELECT 1 FROM information_schema.columns\n"
+            f"       WHERE table_schema='public' AND table_name='{c}'\n"
+            f"         AND column_name='{cc}' AND is_nullable='YES'\n"
+            f"     )\n"
+            f"     AND EXISTS (\n"
+            f"       SELECT 1 FROM information_schema.columns\n"
+            f"       WHERE table_schema='public' AND table_name='{p}'\n"
+            f"         AND column_name='{pc}'\n"
+            f"     ) THEN\n"
+            f"    {orphan_null_sql(c, cc, p, pc)};\n"
+            f"  ELSIF EXISTS (\n"
+            f"       SELECT 1 FROM information_schema.columns\n"
+            f"       WHERE table_schema='public' AND table_name='{c}'\n"
+            f"         AND column_name='{cc}' AND is_nullable='NO'\n"
+            f"     )\n"
+            f"     AND to_regclass('public.{p}') IS NOT NULL THEN\n"
+            f"    {orphan_delete_sql(c, cc, p, pc)};\n"
+            f"  END IF;\n"
+            f"EXCEPTION WHEN OTHERS THEN\n"
+            f"  RAISE NOTICE 'orphan null/delete skipped on {c}.{cc}: %', SQLERRM;\n"
+            f"END $pgclockmg_orphan$;\n"
+        )
+    return "".join(parts)
 
 
 def _sqlite_table_exists(db: sqlite3.Connection, table: str) -> bool:
@@ -393,6 +535,13 @@ def cleanup_orphans_postgres_conn(
                 )
                 if not cur.fetchone():
                     continue
+                cur.execute(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema='public' AND table_name=%s AND column_name=%s LIMIT 1",
+                    (child, child_col),
+                )
+                if not cur.fetchone():
+                    continue
                 cur.execute(orphan_delete_sql(child, child_col, parent, parent_col))
                 deleted += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
             for child, child_col, parent, parent_col in ORPHAN_NULL_SPECS:
@@ -578,7 +727,7 @@ async def heal_orphan_fk_refs(migrator) -> tuple[int, int]:
     if deleted or nulled:
         migrator.job.log(
             f"Orphan FK heal: deleted {deleted} row(s), nulled {nulled} ref(s) "
-            f"(node_usages/node_user_usages/…)"
+            f"(reminders / usages / associations / …)"
         )
     else:
         migrator.job.log("Orphan FK heal: no orphan references found")

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -2960,6 +2960,20 @@ def explain_restore_error(exc: Exception, backup_db: str | None = None, target_d
             "multi-worker: NATS_URL و بالا بودن nats را چک کنید",
             "ممکن است SSL یا SQLALCHEMY_DATABASE_URL اشتباه باشد",
         ]
+    elif (
+        "violates foreign key" in low
+        or "foreign key constraint" in low
+        or "is not present in table" in low
+        or ("1452" in low and "foreign key" in low)
+    ):
+        fa = "دامپ بکاپ ردیف یتیم دارد (ارجاع به کاربر/نود حذف‌شده)."
+        en = "Backup dump has orphan rows (references to deleted users/nodes)."
+        ru = "В дампе есть осиротевшие строки (ссылки на удалённых пользователей/ноды)."
+        causes_fa = [
+            "مثلاً notification_reminders به user_idای اشاره می‌کند که در users نیست",
+            "ویزارد جدید این ردیف‌های یتیم را هنگام ریستور حذف می‌کند — دوباره تلاش کنید",
+            "دادهٔ اصلی کاربران/نودها دست‌نخورده می‌ماند؛ فقط یادآورها/لاگ‌های یتیم پاک می‌شوند",
+        ]
     elif "cannot stage" in low and ("timescaledb" in low or "postgresql" in low):
         fa = "دامپ Timescale/PostgreSQL برای تبدیل استیج نشد (سرویس مبدأ روی سرور نیست)."
         en = "Could not stage Timescale/PostgreSQL dump for conversion (source engine not running)."
@@ -4176,6 +4190,81 @@ async def _restore_mysql(
 
     last_err = ""
     best_err = ""
+    from app.services.marzban_preboot_heal import (
+        orphan_delete_sql,
+        ORPHAN_DELETE_SPECS,
+        ORPHAN_NULL_SPECS,
+        write_orphan_tolerant_mysql_dump,
+    )
+
+    wrapped_dump = import_dump.parent / f".{import_dump.name}.orphan-tolerant.sql"
+    try:
+        write_orphan_tolerant_mysql_dump(import_dump, wrapped_dump)
+        pipe_dump = wrapped_dump
+    except OSError as exc:
+        job.log(f"MySQL orphan-tolerant wrap skipped ({exc}) — importing dump as-is")
+        pipe_dump = import_dump
+
+    async def _heal_mysql_orphans_after_restore(
+        *, mysql_cmd: str, user: str, pwd: str, db: str | None,
+    ) -> None:
+        """Best-effort delete of dangling FK child rows after dump import."""
+        target_db = db or db_name
+        if not target_db:
+            return
+        deleted = 0
+        for child, child_col, parent, parent_col in ORPHAN_DELETE_SPECS:
+            sql = orphan_delete_sql(child, child_col, parent, parent_col) + ";"
+            cmd = [
+                "docker", "compose", "exec", "-T",
+                "-e", f"MYSQL_PWD={pwd}", svc, mysql_cmd, "-u", user, target_db,
+                "-e", sql,
+            ]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=str(PASARGUARD_DIR),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out_b, _ = await proc.communicate()
+            if proc.returncode == 0:
+                # mysql CLI does not always print rowcounts; treat success as soft progress
+                deleted += 1
+        # NULL-style specs: attempt UPDATE; if it fails (NOT NULL), DELETE instead.
+        from app.services.marzban_preboot_heal import orphan_null_sql
+
+        for child, child_col, parent, parent_col in ORPHAN_NULL_SPECS:
+            sql = orphan_null_sql(child, child_col, parent, parent_col) + ";"
+            cmd = [
+                "docker", "compose", "exec", "-T",
+                "-e", f"MYSQL_PWD={pwd}", svc, mysql_cmd, "-u", user, target_db,
+                "-e", sql,
+            ]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=str(PASARGUARD_DIR),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            await proc.communicate()
+            if proc.returncode != 0:
+                sql = orphan_delete_sql(child, child_col, parent, parent_col) + ";"
+                cmd[-1] = sql
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    cwd=str(PASARGUARD_DIR),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                )
+                await proc.communicate()
+        if deleted:
+            job.log(
+                f"Orphan FK heal after MySQL dump import: scanned {deleted} child "
+                "table spec(s) (reminders / usages / associations)"
+            )
+        else:
+            job.log("Orphan FK heal after MySQL dump import: no matching child tables")
+
     for user, pwd, db in attempts:
         for mysql_cmd in client_bins:
             cmd = [
@@ -4185,7 +4274,7 @@ async def _restore_mysql(
             if db:
                 cmd.append(db)
             job.log(f"Trying MySQL restore as {user}" + (f"/{db}" if db else "") + f" ({mysql_cmd})")
-            with open(import_dump, "rb") as dump_fh:
+            with open(pipe_dump, "rb") as dump_fh:
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     cwd=str(PASARGUARD_DIR),
@@ -4198,8 +4287,19 @@ async def _restore_mysql(
             if proc.returncode == 0:
                 job.log("MySQL/MariaDB dump restored")
                 try:
+                    await _heal_mysql_orphans_after_restore(
+                        mysql_cmd=mysql_cmd, user=user, pwd=pwd, db=db,
+                    )
+                except Exception as heal_exc:
+                    job.log(f"MySQL orphan FK heal note: {heal_exc}")
+                try:
                     if sanitized.exists() and sanitized.resolve() != dump.resolve():
                         sanitized.unlink()
+                except OSError:
+                    pass
+                try:
+                    if wrapped_dump.exists():
+                        wrapped_dump.unlink()
                 except OSError:
                     pass
                 return
@@ -4214,6 +4314,11 @@ async def _restore_mysql(
     try:
         if sanitized.exists() and sanitized.resolve() != dump.resolve():
             sanitized.unlink()
+    except OSError:
+        pass
+    try:
+        if wrapped_dump.exists():
+            wrapped_dump.unlink()
     except OSError:
         pass
     raise RuntimeError(
@@ -4393,15 +4498,80 @@ async def _restore_postgres(
         return n >= 3, f"core_tables={n}"
 
     async def restore_dump_file(dbn: str, path: Path, *, tolerant: bool) -> tuple[bool, str]:
-        ok, out = await psql("", db=dbn, use_file=path, on_error_stop=not tolerant)
+        """Import a plain-SQL dump with orphan-FK tolerance, then heal leftovers.
+
+        Dirty PasarGuard dumps may reference deleted users (e.g. notification_reminders).
+        We defer FK checks for the import session when permitted, then delete orphan
+        child rows so constraints hold again — clean dumps are unchanged (heal is a no-op).
+        """
+        from app.services.marzban_preboot_heal import (
+            logs_indicate_orphan_fk,
+            write_orphan_tolerant_pg_dump,
+        )
+
+        wrapped = path.parent / f".{path.name}.orphan-tolerant.sql"
+        ok, out = False, ""
+
+        async def _import_wrapped(*, pg_user: str, pg_password: str) -> tuple[bool, str]:
+            stop = "ON_ERROR_STOP=1" if not tolerant else "ON_ERROR_STOP=0"
+            cmd = [
+                "docker", "compose", "exec", "-T",
+                "-e", f"PGPASSWORD={pg_password}",
+                svc, "psql", "-v", stop, "-U", pg_user, "-d", dbn,
+            ]
+            with open(wrapped, "rb") as sql_fh:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    cwd=str(PASARGUARD_DIR),
+                    stdin=sql_fh,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                )
+                out_b, _ = await proc.communicate()
+            return proc.returncode == 0, (out_b or b"").decode("utf-8", errors="replace")
+
+        try:
+            write_orphan_tolerant_pg_dump(path, wrapped)
+            ok, out = await _import_wrapped(pg_user=user, pg_password=password)
+            # Non-superuser sessions cannot set session_replication_role=replica, so
+            # orphan COPYs still abort. Retry once as the container bootstrap role.
+            if (
+                not ok
+                and not tolerant
+                and logs_indicate_orphan_fk(out or "")
+            ):
+                su = (container_env.get("POSTGRES_USER") or "").strip()
+                sp = container_env.get("POSTGRES_PASSWORD") or password
+                if su and (su != user or sp != password):
+                    job.log(
+                        f"Orphan FK during dump import — retrying as container role `{su}` "
+                        "with FK checks deferred…"
+                    )
+                    ok2, out2 = await _import_wrapped(pg_user=su, pg_password=sp or password)
+                    if ok2:
+                        ok, out = ok2, out2
+                    else:
+                        out = (out or "") + "\n" + (out2 or "")
+        finally:
+            try:
+                wrapped.unlink(missing_ok=True)
+            except TypeError:
+                try:
+                    if wrapped.exists():
+                        wrapped.unlink()
+                except OSError:
+                    pass
+            except OSError:
+                pass
+
         if tolerant:
-            # Non-zero is OK if leftover Timescale noise failed — verify panel tables
             verified, detail = await verify_app_tables(dbn)
             if verified:
                 errs = extract_psql_errors(out)
                 if errs:
                     job.log(f"Dump import had non-fatal errors (ignored):\n{errs[:600]}")
                 job.log(f"Verified app schema after tolerant restore ({detail})")
+                await _heal_pg_orphans_after_restore(dbn)
                 return True, out
             return False, (
                 f"Tolerant restore did not create core tables ({detail}).\n"
@@ -4409,7 +4579,49 @@ async def _restore_postgres(
             )
         if not ok:
             return False, extract_psql_errors(out) or out
+        await _heal_pg_orphans_after_restore(dbn)
         return True, out
+
+    async def _heal_pg_orphans_after_restore(dbn: str) -> None:
+        from app.services.marzban_preboot_heal import orphan_cleanup_sql_script
+
+        script = orphan_cleanup_sql_script()
+        tmp = Path(f"/tmp/pgclockmg-orphan-heal-{dbn}.sql")
+        try:
+            tmp.write_text(script, encoding="utf-8")
+            ok, out = await psql("", db=dbn, use_file=tmp, on_error_stop=False)
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except TypeError:
+                try:
+                    if tmp.exists():
+                        tmp.unlink()
+                except OSError:
+                    pass
+            except OSError:
+                pass
+        # Prefer counting DELETE lines from psql notice/output when present.
+        deleted_hint = 0
+        for line in (out or "").splitlines():
+            s = line.strip()
+            if s.upper().startswith("DELETE "):
+                try:
+                    deleted_hint += int(s.split()[-1])
+                except ValueError:
+                    pass
+        if deleted_hint:
+            job.log(
+                f"Orphan FK heal after dump import on `{dbn}`: removed {deleted_hint} "
+                "dangling child row(s) (reminders / usages / associations)"
+            )
+        elif ok:
+            job.log(f"Orphan FK heal after dump import on `{dbn}`: no dangling rows")
+        else:
+            job.log(
+                f"Orphan FK heal note on `{dbn}`: "
+                f"{(extract_psql_errors(out) or out or '')[:400]}"
+            )
 
     layout = analysis.get("layout")
     manifest = root / "pg_dump" / "manifest.tsv"

--- a/tests/test_marzban_preboot_heal.py
+++ b/tests/test_marzban_preboot_heal.py
@@ -32,7 +32,74 @@ def test_logs_indicate_orphan_fk():
     )
     assert logs_indicate_orphan_fk(sample) is True
     assert logs_indicate_orphan_fk("Duplicate entry 'usa-reality'") is False
+
+    pg_sample = (
+        'ERROR: insert or update on table "notification_reminders" '
+        'violates foreign key constraint "fk_notification_reminders_user_id_users"\n'
+        "DETAIL: Key (user_id)=(26) is not present in table \"users\"."
+    )
+    assert logs_indicate_orphan_fk(pg_sample) is True
     print("OK: orphan fk log detector")
+
+
+def test_cleanup_orphans_sqlite_removes_notification_reminders():
+    """PasarGuard dumps with orphan reminders must heal without inventing users."""
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "db.sqlite3"
+        db = sqlite3.connect(str(path))
+        db.executescript(
+            """
+            CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT);
+            CREATE TABLE admins (id INTEGER PRIMARY KEY, username TEXT);
+            CREATE TABLE notification_reminders (
+                id INTEGER PRIMARY KEY, user_id INTEGER
+            );
+            CREATE TABLE admin_notification_reminders (
+                id INTEGER PRIMARY KEY, admin_id INTEGER
+            );
+            CREATE TABLE user_hwids (id INTEGER PRIMARY KEY, user_id INTEGER);
+
+            INSERT INTO users VALUES (1, 'alive');
+            INSERT INTO admins VALUES (1, 'root');
+            INSERT INTO notification_reminders VALUES (1, 1);
+            INSERT INTO notification_reminders VALUES (2, 26);  -- orphan
+            INSERT INTO admin_notification_reminders VALUES (1, 1);
+            INSERT INTO admin_notification_reminders VALUES (2, 99);  -- orphan
+            INSERT INTO user_hwids VALUES (1, 1);
+            INSERT INTO user_hwids VALUES (2, 26);  -- orphan
+            """
+        )
+        db.commit()
+        db.close()
+
+        deleted, nulled = cleanup_orphans_sqlite(path)
+        assert deleted == 3
+        assert nulled == 0
+
+        db = sqlite3.connect(str(path))
+        assert [r[0] for r in db.execute("SELECT id FROM notification_reminders")] == [1]
+        assert [r[0] for r in db.execute("SELECT id FROM admin_notification_reminders")] == [1]
+        assert [r[0] for r in db.execute("SELECT id FROM user_hwids")] == [1]
+        assert [r[0] for r in db.execute("SELECT id FROM users")] == [1]
+        db.close()
+        assert cleanup_orphans_sqlite(path) == (0, 0)
+    print("OK: sqlite notification_reminders orphan cleanup")
+
+
+def test_write_orphan_tolerant_pg_dump_wraps_session_role():
+    from app.services.marzban_preboot_heal import write_orphan_tolerant_pg_dump
+
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(td) / "dump.sql"
+        dest = Path(td) / "wrapped.sql"
+        src.write_text("COPY public.users FROM stdin;\n1\tfoo\n\\.\n", encoding="utf-8")
+        write_orphan_tolerant_pg_dump(src, dest)
+        text = dest.read_text(encoding="utf-8")
+        assert "session_replication_role" in text
+        assert "COPY public.users FROM stdin;" in text
+        assert text.index("replica") < text.index("COPY public.users")
+        assert text.rindex("origin") > text.index("COPY public.users")
+    print("OK: orphan-tolerant pg dump wrap")
 
 
 def test_cleanup_orphans_sqlite_removes_only_orphans():
@@ -227,6 +294,8 @@ if __name__ == "__main__":
     test_orphan_delete_sql_shape()
     test_logs_indicate_orphan_fk()
     test_cleanup_orphans_sqlite_removes_only_orphans()
+    test_cleanup_orphans_sqlite_removes_notification_reminders()
+    test_write_orphan_tolerant_pg_dump_wraps_session_role()
     test_cleanup_orphans_noop_on_clean_db()
     test_shrink_heavy_usage_sqlite_threshold()
     test_orphan_null_falls_back_to_delete_when_not_null()

--- a/tests/test_pg_restore.py
+++ b/tests/test_pg_restore.py
@@ -785,6 +785,20 @@ def test_explain_schema_name_chunk_error():
     print("OK: explain schema_name chunk error")
 
 
+def test_explain_orphan_fk_notification_reminders():
+    exc = RuntimeError(
+        'PostgreSQL dump restore failed: ERROR: insert or update on table '
+        '"notification_reminders" violates foreign key constraint '
+        '"fk_notification_reminders_user_id_users"\n'
+        "DETAIL: Key (user_id)=(26) is not present in table \"users\"."
+    )
+    info = explain_restore_error(exc, "postgresql", "timescaledb")
+    blob = (info.get("en") or "") + (info.get("fa") or "")
+    assert "orphan" in blob.lower() or "یتیم" in blob
+    assert info.get("causes_fa")
+    print("OK: explain orphan FK notification_reminders")
+
+
 def test_collect_backup_ts_from_compose_and_catalog():
     import tempfile
     import shutil
@@ -1357,6 +1371,7 @@ if __name__ == "__main__":
     test_align_image_failed_pull_keeps_data_and_tag()
     test_explain_newer_ts_backup_error()
     test_explain_schema_name_chunk_error()
+    test_explain_orphan_fk_notification_reminders()
     test_collect_backup_ts_from_compose_and_catalog()
     test_is_auth_failure_text()
     test_sql_literal_escapes_quotes()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Restore of dirty PasarGuard dumps (e.g. `postgresql → timescaledb`) could hard-fail when child tables like `notification_reminders` referenced deleted users:

`violates foreign key constraint fk_notification_reminders_user_id_users — Key (user_id)=(26) is not present in table "users"`

## Approach
- **No fake users** — only remove dangling soft-child rows
- **PG/Timescale dump import**: wrap dump with `session_replication_role=replica` (best-effort), import, then run shared orphan-cleanup SQL; retry once as container bootstrap role if non-superuser blocked deferral
- **MySQL dump import**: wrap with `FOREIGN_KEY_CHECKS=0/1`, then post-import orphan heal
- **Shared catalog** expanded for PasarGuard soft children: reminders, hwids, subscription updates, group/inbound associations (plus existing node usages / next_plans)
- **Clean dumps**: heal is a no-op
- Clearer `explain_restore_error` copy when an orphan FK still surfaces

## Test plan
- [x] `python3 tests/test_marzban_preboot_heal.py` (includes notification_reminders orphan + dump wrap)
- [x] `explain_restore_error` detects orphan FK wording
- [ ] Re-run the failing restore: postgresql backup → timescaledb install with orphan reminders

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

