### PR TITLE
fix: PG dump import as superuser so orphan FK heal actually runs

### DIFF
--- a/app/services/marzban_preboot_heal.py
+++ b/app/services/marzban_preboot_heal.py
@@ -131,49 +131,137 @@ def logs_indicate_orphan_fk(logs: str) -> bool:
     )
 
 
-def orphan_fk_defer_prefix_sql() -> str:
-    """Best-effort PG session preamble so dirty dumps can load before orphan heal.
+def orphan_fk_defer_prefix_sql(
+    *,
+    strict: bool = False,
+    set_role: str | None = None,
+) -> str:
+    """PG session preamble so dirty dumps can load before orphan heal.
 
-    ``session_replication_role=replica`` skips FK triggers (superuser). When the
-    role lacks privilege the DO block only raises a NOTICE and import continues;
-    a subsequent orphan heal still cleans whatever landed, and a hard FK abort
-    still surfaces for the caller to retry with a privileged role if needed.
+    ``session_replication_role=replica`` skips FK triggers (superuser).
+
+    - ``strict=True``: bare ``SET`` so a non-superuser fails immediately instead of
+      continuing into a doomed COPY that aborts mid-dump.
+    - ``set_role``: after deferring FKs, assume the app DB owner so newly created
+      objects keep the correct owner when import runs as bootstrap superuser.
     """
-    return (
-        "-- PGClockMG: defer FK checks for orphan-tolerant dump import\n"
-        "DO $pgclockmg_fk$ BEGIN\n"
-        "  PERFORM set_config('session_replication_role', 'replica', false);\n"
-        "EXCEPTION\n"
-        "  WHEN insufficient_privilege THEN\n"
-        "    RAISE NOTICE 'session_replication_role=replica denied (non-superuser)';\n"
-        "  WHEN OTHERS THEN\n"
-        "    RAISE NOTICE 'session_replication_role=replica skipped: %', SQLERRM;\n"
-        "END $pgclockmg_fk$;\n"
-    )
+    parts = ["-- PGClockMG: defer FK checks for orphan-tolerant dump import\n"]
+    if strict:
+        parts.append("SET session_replication_role = replica;\n")
+    else:
+        parts.append(
+            "DO $pgclockmg_fk$ BEGIN\n"
+            "  PERFORM set_config('session_replication_role', 'replica', false);\n"
+            "EXCEPTION\n"
+            "  WHEN insufficient_privilege THEN\n"
+            "    RAISE NOTICE 'session_replication_role=replica denied (non-superuser)';\n"
+            "  WHEN OTHERS THEN\n"
+            "    RAISE NOTICE 'session_replication_role=replica skipped: %', SQLERRM;\n"
+            "END $pgclockmg_fk$;\n"
+        )
+    role = (set_role or "").strip()
+    if role:
+        parts.append(f"SET ROLE {_ident(role)};\n")
+    return "".join(parts)
 
 
-def orphan_fk_defer_suffix_sql() -> str:
-    return (
-        "\nDO $pgclockmg_fk$ BEGIN\n"
-        "  PERFORM set_config('session_replication_role', 'origin', false);\n"
-        "EXCEPTION WHEN OTHERS THEN\n"
-        "  NULL;\n"
-        "END $pgclockmg_fk$;\n"
-    )
+def orphan_fk_defer_suffix_sql(
+    *,
+    strict: bool = False,
+    set_role: str | None = None,
+) -> str:
+    parts = ["\n"]
+    if (set_role or "").strip():
+        parts.append("RESET ROLE;\n")
+    if strict:
+        parts.append("SET session_replication_role = origin;\n")
+    else:
+        parts.append(
+            "DO $pgclockmg_fk$ BEGIN\n"
+            "  PERFORM set_config('session_replication_role', 'origin', false);\n"
+            "EXCEPTION WHEN OTHERS THEN\n"
+            "  NULL;\n"
+            "END $pgclockmg_fk$;\n"
+        )
+    return "".join(parts)
 
 
-def write_orphan_tolerant_pg_dump(src: Path, dest: Path) -> Path:
+def write_orphan_tolerant_pg_dump(
+    src: Path,
+    dest: Path,
+    *,
+    strict: bool = False,
+    set_role: str | None = None,
+) -> Path:
     """Copy ``src`` to ``dest`` wrapped with FK-defer preamble/epilogue."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     with open(src, "rb") as inf, open(dest, "wb") as outf:
-        outf.write(orphan_fk_defer_prefix_sql().encode("utf-8"))
+        outf.write(
+            orphan_fk_defer_prefix_sql(strict=strict, set_role=set_role).encode("utf-8")
+        )
         while True:
             chunk = inf.read(1024 * 1024)
             if not chunk:
                 break
             outf.write(chunk)
-        outf.write(orphan_fk_defer_suffix_sql().encode("utf-8"))
+        outf.write(
+            orphan_fk_defer_suffix_sql(strict=strict, set_role=set_role).encode("utf-8")
+        )
     return dest
+
+
+# Soft child tables whose *data* may be dropped as a last-resort restore fallback
+# when no PostgreSQL superuser is available to defer FK checks. Schema is kept.
+# Keep this narrower than ORPHAN_DELETE_SPECS — wiping node_*_usages wholesale
+# would discard valid traffic history; reminders/hwids/associations are safe to
+# empty when their parent rows are missing.
+_SOFT_ORPHAN_COPY_TABLES = frozenset({
+    "notification_reminders",
+    "admin_notification_reminders",
+    "user_hwids",
+    "user_subscription_updates",
+    "users_groups_association",
+    "exclude_inbounds_association",
+    "next_plans",
+})
+
+_COPY_TABLE_RE = re.compile(
+    r'^COPY\s+(?:public\.)?"?([A-Za-z_][A-Za-z0-9_]*)"?\s*\([^;]*\)\s+FROM\s+stdin\s*;\s*$',
+    re.IGNORECASE,
+)
+
+
+def strip_soft_orphan_copy_data_from_pg_dump(src: Path, dest: Path) -> dict[str, int]:
+    """Keep schema but drop COPY payloads for soft orphan-prone child tables.
+
+    Used when dump import cannot defer FK checks (no superuser). Empty COPY
+    blocks remain so the table still exists; only row data is skipped.
+    Returns ``{table: skipped_row_count}``.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    skipped: dict[str, int] = {}
+    skipping: str | None = None
+    with open(src, "r", encoding="utf-8", errors="replace") as inf, open(
+        dest, "w", encoding="utf-8"
+    ) as outf:
+        for line in inf:
+            if skipping is not None:
+                if line.startswith("\\.") or line.strip() == "\\.":
+                    outf.write(line)
+                    skipping = None
+                else:
+                    # data row (or comment inside COPY) — drop it
+                    if line.strip() and not line.startswith("--"):
+                        skipped[skipping] = skipped.get(skipping, 0) + 1
+                continue
+            m = _COPY_TABLE_RE.match(line.rstrip("\n"))
+            if m and m.group(1).lower() in _SOFT_ORPHAN_COPY_TABLES:
+                skipping = m.group(1).lower()
+                skipped.setdefault(skipping, 0)
+                outf.write(line)
+                continue
+            outf.write(line)
+    return {k: v for k, v in skipped.items() if v > 0}
 
 
 def mysql_fk_checks_off_sql() -> str:

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -4501,8 +4501,11 @@ async def _restore_postgres(
         """Import a plain-SQL dump with orphan-FK tolerance, then heal leftovers.
 
         Dirty PasarGuard dumps may reference deleted users (e.g. notification_reminders).
-        We defer FK checks for the import session when permitted, then delete orphan
-        child rows so constraints hold again — clean dumps are unchanged (heal is a no-op).
+        FK deferral requires a superuser session; we probe for one (container
+        POSTGRES_USER / postgres / current) and import with a *strict*
+        ``session_replication_role=replica`` wrap. Soft DO/NOTICE wraps are only
+        a last resort — they previously let non-superuser imports continue and
+        abort mid-COPY before orphan heal could run.
         """
         from app.services.marzban_preboot_heal import (
             logs_indicate_orphan_fk,
@@ -4530,28 +4533,167 @@ async def _restore_postgres(
                 out_b, _ = await proc.communicate()
             return proc.returncode == 0, (out_b or b"").decode("utf-8", errors="replace")
 
+        async def _role_is_superuser(pg_user: str, pg_password: str) -> bool:
+            cmd = [
+                "docker", "compose", "exec", "-T",
+                "-e", f"PGPASSWORD={pg_password}",
+                svc, "psql", "-v", "ON_ERROR_STOP=1", "-U", pg_user, "-d", "postgres",
+                "-tAc", "SELECT current_setting('is_superuser')",
+            ]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=str(PASARGUARD_DIR),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out_b, _ = await proc.communicate()
+            text = (out_b or b"").decode("utf-8", errors="replace")
+            if proc.returncode != 0:
+                return False
+            return "on" in text.lower()
+
+        async def _resolve_import_role() -> tuple[str, str, bool]:
+            """Return (user, password, is_superuser) for dump import."""
+            cu = (container_env.get("POSTGRES_USER") or "").strip()
+            cp = container_env.get("POSTGRES_PASSWORD") or password
+            candidates: list[tuple[str, str]] = []
+            if cu and cp:
+                candidates.append((cu, cp))
+            if cp:
+                candidates.append(("postgres", cp))
+            candidates.append((user, password))
+            if cu and password and password != cp:
+                candidates.append((cu, password))
+            candidates.append(("postgres", password))
+            seen: set[tuple[str, str]] = set()
+            for u, p in candidates:
+                if not u or not p or (u, p) in seen:
+                    continue
+                seen.add((u, p))
+                try:
+                    if await _role_is_superuser(u, p):
+                        return u, p, True
+                except Exception:
+                    continue
+            return user, password, False
+
+        import_user, import_password, is_super = await _resolve_import_role()
+        if is_super:
+            if import_user != user:
+                job.log(
+                    f"Dump import as superuser `{import_user}` "
+                    f"(SET ROLE {user} for object ownership; FK checks deferred)"
+                )
+            else:
+                job.log(
+                    f"Dump import as superuser `{import_user}` "
+                    "(FK checks deferred via session_replication_role=replica)"
+                )
+        else:
+            job.log(
+                f"Dump import as `{import_user}` without confirmed superuser — "
+                "orphan FK deferral may fail; will escalate if needed"
+            )
+
         try:
-            write_orphan_tolerant_pg_dump(path, wrapped)
-            ok, out = await _import_wrapped(pg_user=user, pg_password=password)
-            # Non-superuser sessions cannot set session_replication_role=replica, so
-            # orphan COPYs still abort. Retry once as the container bootstrap role.
+            write_orphan_tolerant_pg_dump(
+                path,
+                wrapped,
+                strict=is_super,
+                set_role=(user if is_super and import_user != user else None),
+            )
+            ok, out = await _import_wrapped(
+                pg_user=import_user, pg_password=import_password,
+            )
+
+            # Escalate: orphan FK means deferral did not apply. Probe every
+            # remaining superuser candidate (including postgres) and retry.
             if (
                 not ok
                 and not tolerant
                 and logs_indicate_orphan_fk(out or "")
             ):
-                su = (container_env.get("POSTGRES_USER") or "").strip()
-                sp = container_env.get("POSTGRES_PASSWORD") or password
-                if su and (su != user or sp != password):
+                cu = (container_env.get("POSTGRES_USER") or "").strip()
+                cp = container_env.get("POSTGRES_PASSWORD") or password
+                retry_roles: list[tuple[str, str]] = []
+                for u, p in (
+                    (cu, cp),
+                    ("postgres", cp),
+                    ("postgres", password),
+                    (cu, password),
+                ):
+                    if not u or not p:
+                        continue
+                    if (u, p) == (import_user, import_password):
+                        continue
+                    if (u, p) not in retry_roles:
+                        retry_roles.append((u, p))
+                for su, sp in retry_roles:
+                    try:
+                        if not await _role_is_superuser(su, sp):
+                            continue
+                    except Exception:
+                        continue
                     job.log(
-                        f"Orphan FK during dump import — retrying as container role `{su}` "
-                        "with FK checks deferred…"
+                        f"Orphan FK during dump import — retrying as superuser `{su}` "
+                        "with strict FK deferral…"
                     )
-                    ok2, out2 = await _import_wrapped(pg_user=su, pg_password=sp or password)
+                    write_orphan_tolerant_pg_dump(
+                        path,
+                        wrapped,
+                        strict=True,
+                        set_role=(user if su != user else None),
+                    )
+                    ok2, out2 = await _import_wrapped(pg_user=su, pg_password=sp)
                     if ok2:
                         ok, out = ok2, out2
-                    else:
-                        out = (out or "") + "\n" + (out2 or "")
+                        is_super = True
+                        break
+                    out = (out or "") + "\n" + (out2 or "")
+
+                # Last resort: no usable superuser — strip soft child COPY payloads
+                # (reminders/usages/associations) so FK orphans cannot abort import.
+                # Schema is preserved; only dangling soft-table *data* is skipped.
+                if not ok and logs_indicate_orphan_fk(out or ""):
+                    from app.services.marzban_preboot_heal import (
+                        strip_soft_orphan_copy_data_from_pg_dump,
+                    )
+
+                    stripped = path.parent / f".{path.name}.orphan-data-stripped.sql"
+                    try:
+                        stats = strip_soft_orphan_copy_data_from_pg_dump(path, stripped)
+                        if stats:
+                            job.log(
+                                "No usable superuser for FK deferral — stripping soft "
+                                "orphan table DATA from dump and retrying "
+                                f"(skipped rows: {stats})"
+                            )
+                            write_orphan_tolerant_pg_dump(
+                                stripped, wrapped, strict=False, set_role=None,
+                            )
+                            ok3, out3 = await _import_wrapped(
+                                pg_user=user, pg_password=password,
+                            )
+                            if ok3:
+                                ok, out = ok3, out3
+                            else:
+                                out = (out or "") + "\n" + (out3 or "")
+                        else:
+                            job.log(
+                                "Orphan FK persists but dump has no soft COPY payloads "
+                                "to strip — cannot auto-heal further"
+                            )
+                    finally:
+                        try:
+                            stripped.unlink(missing_ok=True)
+                        except TypeError:
+                            try:
+                                if stripped.exists():
+                                    stripped.unlink()
+                            except OSError:
+                                pass
+                        except OSError:
+                            pass
         finally:
             try:
                 wrapped.unlink(missing_ok=True)

--- a/tests/test_marzban_preboot_heal.py
+++ b/tests/test_marzban_preboot_heal.py
@@ -99,7 +99,53 @@ def test_write_orphan_tolerant_pg_dump_wraps_session_role():
         assert "COPY public.users FROM stdin;" in text
         assert text.index("replica") < text.index("COPY public.users")
         assert text.rindex("origin") > text.index("COPY public.users")
+
+        strict_dest = Path(td) / "strict.sql"
+        write_orphan_tolerant_pg_dump(
+            src, strict_dest, strict=True, set_role="pasarguard",
+        )
+        st = strict_dest.read_text(encoding="utf-8")
+        assert "SET session_replication_role = replica;" in st
+        assert "SET ROLE pasarguard;" in st
+        assert "RESET ROLE;" in st
+        assert "SET session_replication_role = origin;" in st
+        assert "DO $pgclockmg_fk$" not in st
     print("OK: orphan-tolerant pg dump wrap")
+
+
+def test_strip_soft_orphan_copy_data_from_pg_dump():
+    from app.services.marzban_preboot_heal import strip_soft_orphan_copy_data_from_pg_dump
+
+    dump = "\n".join([
+        "CREATE TABLE public.users (id integer);",
+        "COPY public.users (id) FROM stdin;",
+        "1",
+        "26",
+        "\\.",
+        "CREATE TABLE public.notification_reminders (id integer, user_id integer);",
+        "COPY public.notification_reminders (id, user_id) FROM stdin;",
+        "1\t1",
+        "2\t26",
+        "\\.",
+        "COPY public.hosts (id, remark) FROM stdin;",
+        "9\tok",
+        "\\.",
+        "",
+    ])
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(td) / "in.sql"
+        dest = Path(td) / "out.sql"
+        src.write_text(dump, encoding="utf-8")
+        stats = strip_soft_orphan_copy_data_from_pg_dump(src, dest)
+        assert stats.get("notification_reminders") == 2
+        assert "hosts" not in stats
+        out = dest.read_text(encoding="utf-8")
+        assert "COPY public.users (id) FROM stdin;\n1\n26\n\\.\n" in out
+        assert "COPY public.notification_reminders (id, user_id) FROM stdin;\n\\.\n" in out
+        assert "2\t26" not in out
+        assert "COPY public.hosts (id, remark) FROM stdin;\n9\tok\n\\.\n" in out
+        assert "CREATE TABLE public.notification_reminders" in out
+    print("OK: strip soft orphan COPY data from pg dump")
 
 
 def test_cleanup_orphans_sqlite_removes_only_orphans():
@@ -296,6 +342,7 @@ if __name__ == "__main__":
     test_cleanup_orphans_sqlite_removes_only_orphans()
     test_cleanup_orphans_sqlite_removes_notification_reminders()
     test_write_orphan_tolerant_pg_dump_wraps_session_role()
+    test_strip_soft_orphan_copy_data_from_pg_dump()
     test_cleanup_orphans_noop_on_clean_db()
     test_shrink_heavy_usage_sqlite_threshold()
     test_orphan_null_falls_back_to_delete_when_not_null()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
v4.5.2 still failed on dirty dumps like:
```
ERROR: insert or update on table "notification_reminders" violates foreign key constraint ...
Key (user_id)=(26) is not present in table "users"
```

**Root cause:** orphan heal only runs *after* a successful dump import, but non-superuser sessions cannot `SET session_replication_role = replica`. The soft DO/NOTICE wrap swallowed that failure, COPY still hit the FK, and heal never ran. Retry as `POSTGRES_USER` was skipped when it matched the app user.

## Fix
1. **Probe for a real superuser** (`POSTGRES_USER` / `postgres` / current) before import
2. **Strict** `SET session_replication_role = replica` (no silent continue) + `SET ROLE` app owner for correct ownership
3. **Escalate** across remaining superuser candidates on orphan FK failure
4. **Last resort:** strip soft child COPY payloads (reminders / hwids / associations / next_plans) so restore can finish without a superuser

## Test plan
- [x] `python3 tests/test_marzban_preboot_heal.py`
- [ ] Re-run postgresql → timescaledb restore with orphan `notification_reminders`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

