### PR TITLE
chore: release v4.5.3

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-> 🚀 **`v4.5.2`** — heal orphan FK rows on restore (`notification_reminders` and similar)
+> 🚀 **`v4.5.3`** — PG dump import as superuser so orphan FK heal actually runs
 > ⚠️ Always take a full backup before restore or migration.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div dir="rtl" align="right">
 
-> 🚀 **`v4.5.2`** — heal ردیف‌های یتیم FK هنگام ریستور (`notification_reminders` و مشابه)
+> 🚀 **`v4.5.3`** — ریستور دامپ PG با superuser تا heal یتیم‌های FK واقعاً اجرا شود
 > ⚠️ قبل از ریستور یا مهاجرت حتماً بکاپ کامل بگیرید.
 
 <p align="center">

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,4 +1,4 @@
-> 🚀 **`v4.5.2`** — heal orphan FK rows при restore (`notification_reminders` и аналоги)
+> 🚀 **`v4.5.3`** — импорт PG dump от superuser, чтобы orphan FK heal реально сработал
 > ⚠️ Перед restore или миграцией сделайте полный бэкап.
 
 <p align="center">

--- a/app/backup_main.py
+++ b/app/backup_main.py
@@ -43,7 +43,7 @@ from app.services.backup_telegram import (
 )
 from app.services.prerequisites import get_system_status, is_pasarguard_installed
 
-APP_VERSION = "4.5.2"
+APP_VERSION = "4.5.3"
 
 
 def _dashboard_update_info() -> dict:

--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,7 @@ from app.services.self_uninstall import uninstall_preview, schedule_self_uninsta
 from app.services.auth import COOKIE_NAME, COOKIE_MAX_AGE, ensure_token, token_matches
 from app.config import WEB_PORT
 
-APP_VERSION = "4.5.2"
+APP_VERSION = "4.5.3"
 
 
 @asynccontextmanager

--- a/app/static/backup.html
+++ b/app/static/backup.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG Backup</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=4.5.2">
-  <link rel="stylesheet" href="/static/css/backup.css?v=4.5.2">
+  <link rel="stylesheet" href="/static/css/style.css?v=4.5.3">
+  <link rel="stylesheet" href="/static/css/backup.css?v=4.5.3">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Vazirmatn:wght@400;500;600;700&display=swap" media="print" onload="this.media='all'">
@@ -76,7 +76,7 @@
         </div>
         <div class="header-titles">
           <h1>PGClockMG Backup</h1>
-          <p class="header-version" id="appVersion">v4.5.2</p>
+          <p class="header-version" id="appVersion">v4.5.3</p>
         </div>
       </div>
       <div class="header-meta">
@@ -605,6 +605,6 @@
     </div>
   </div>
 
-  <script src="/static/js/backup.js?v=4.5.2"></script>
+  <script src="/static/js/backup.js?v=4.5.3"></script>
 </body>
 </html>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#0f1218">
   <title>PGClockMG</title>
-  <link rel="stylesheet" href="/static/css/style.css?v=4.5.2">
+  <link rel="stylesheet" href="/static/css/style.css?v=4.5.3">
   <!-- Fonts: non-blocking so mobile/Iran networks don't stall first paint -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -42,7 +42,7 @@
         </div>
         <div>
           <h1>PGClockMG</h1>
-          <p class="header-version" id="appVersion">v4.5.2</p>
+          <p class="header-version" id="appVersion">v4.5.3</p>
         </div>
       </div>
       <div class="header-meta">
@@ -671,9 +671,9 @@
   </div>
 
   <script src="/static/js/icons.js?v=1.1beta.13"></script>
-  <script src="/static/js/i18n.js?v=4.5.2"></script>
-  <script src="/static/js/app.js?v=4.5.2"></script>
-  <script src="/static/js/wizard-flow.js?v=4.5.2"></script>
+  <script src="/static/js/i18n.js?v=4.5.3"></script>
+  <script src="/static/js/app.js?v=4.5.3"></script>
+  <script src="/static/js/wizard-flow.js?v=4.5.3"></script>
 </body>
 </html>
 

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@
 #
 set -eo pipefail
 
-readonly SCRIPT_VERSION="4.5.2"
+readonly SCRIPT_VERSION="4.5.3"
 readonly INSTALL_DIR="${PG_MIGRATOR_INSTALL_DIR:-/opt/pg-migrator}"
 readonly BACKUP_INSTALL_DIR="${PG_BACKUP_INSTALL_DIR:-/opt/pg-backup}"
 readonly SERVICE_NAME="pg-migrator"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump panel version to **v4.5.3** for the PostgreSQL restore orphan-FK import fix from #107 (superuser strict deferral + soft COPY strip fallback).
- Users who still hit orphan `notification_reminders` FK failures on postgresql → timescaledb restore should upgrade and retry.

## Test plan
- [x] Version strings bumped in install/app/README/static
- [ ] Merge and cut GitHub release `v4.5.3`
- [ ] User retests restore with orphan reminders dump

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

