### PR TITLE
fix: keep user↔group links when stripping soft orphan dump data

### DIFF
--- a/app/services/marzban_preboot_heal.py
+++ b/app/services/marzban_preboot_heal.py
@@ -212,16 +212,15 @@ def write_orphan_tolerant_pg_dump(
 
 # Soft child tables whose *data* may be dropped as a last-resort restore fallback
 # when no PostgreSQL superuser is available to defer FK checks. Schema is kept.
-# Keep this narrower than ORPHAN_DELETE_SPECS — wiping node_*_usages wholesale
-# would discard valid traffic history; reminders/hwids/associations are safe to
-# empty when their parent rows are missing.
+# Keep this narrower than ORPHAN_DELETE_SPECS — never wholesale-strip tables that
+# VERIFY / STRICT_COMPLETE require (users_groups_association, exclude_inbounds_*).
+# Those stay in the dump; orphan rows are removed after import by orphan heal.
+# Wiping associations made restores look "successful" then fail verify with 0 links.
 _SOFT_ORPHAN_COPY_TABLES = frozenset({
     "notification_reminders",
     "admin_notification_reminders",
     "user_hwids",
     "user_subscription_updates",
-    "users_groups_association",
-    "exclude_inbounds_association",
     "next_plans",
 })
 

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -4651,9 +4651,10 @@ async def _restore_postgres(
                         break
                     out = (out or "") + "\n" + (out2 or "")
 
-                # Last resort: no usable superuser — strip soft child COPY payloads
-                # (reminders/usages/associations) so FK orphans cannot abort import.
-                # Schema is preserved; only dangling soft-table *data* is skipped.
+                # Last resort: no usable superuser — strip disposable soft child
+                # COPY payloads (reminders/hwids/next_plans only). Never strip
+                # users_groups_association / exclude_inbounds — those are required
+                # for a usable panel and by restore verification.
                 if not ok and logs_indicate_orphan_fk(out or ""):
                     from app.services.marzban_preboot_heal import (
                         strip_soft_orphan_copy_data_from_pg_dump,
@@ -4664,9 +4665,9 @@ async def _restore_postgres(
                         stats = strip_soft_orphan_copy_data_from_pg_dump(path, stripped)
                         if stats:
                             job.log(
-                                "No usable superuser for FK deferral — stripping soft "
-                                "orphan table DATA from dump and retrying "
-                                f"(skipped rows: {stats})"
+                                "No usable superuser for FK deferral — stripping "
+                                "disposable soft-table DATA (not user↔group links) "
+                                f"and retrying (skipped rows: {stats})"
                             )
                             write_orphan_tolerant_pg_dump(
                                 stripped, wrapped, strict=False, set_role=None,

--- a/tests/test_marzban_preboot_heal.py
+++ b/tests/test_marzban_preboot_heal.py
@@ -127,6 +127,13 @@ def test_strip_soft_orphan_copy_data_from_pg_dump():
         "1\t1",
         "2\t26",
         "\\.",
+        "COPY public.users_groups_association (user_id, group_id) FROM stdin;",
+        "1\t1",
+        "26\t2",
+        "\\.",
+        "COPY public.exclude_inbounds_association (user_id, inbound_id) FROM stdin;",
+        "1\t9",
+        "\\.",
         "COPY public.hosts (id, remark) FROM stdin;",
         "9\tok",
         "\\.",
@@ -139,10 +146,14 @@ def test_strip_soft_orphan_copy_data_from_pg_dump():
         stats = strip_soft_orphan_copy_data_from_pg_dump(src, dest)
         assert stats.get("notification_reminders") == 2
         assert "hosts" not in stats
+        assert "users_groups_association" not in stats
+        assert "exclude_inbounds_association" not in stats
         out = dest.read_text(encoding="utf-8")
         assert "COPY public.users (id) FROM stdin;\n1\n26\n\\.\n" in out
         assert "COPY public.notification_reminders (id, user_id) FROM stdin;\n\\.\n" in out
         assert "2\t26" not in out
+        assert "COPY public.users_groups_association (user_id, group_id) FROM stdin;\n1\t1\n26\t2\n\\.\n" in out
+        assert "COPY public.exclude_inbounds_association (user_id, inbound_id) FROM stdin;\n1\t9\n\\.\n" in out
         assert "COPY public.hosts (id, remark) FROM stdin;\n9\tok\n\\.\n" in out
         assert "CREATE TABLE public.notification_reminders" in out
     print("OK: strip soft orphan COPY data from pg dump")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Last-resort orphan FK dump strip no longer wipes `users_groups_association` / `exclude_inbounds_association`.
- Those tables are required for a usable panel and by restore verification; wiping them caused `users_groups_association: 0/214` while users/groups/inbounds restored fine.
- Strip list is now only disposable soft tables (reminders, hwids, subscription updates, next_plans). Association orphans still go through post-import heal DELETE.

## Test plan
- [x] `python3 tests/test_marzban_preboot_heal.py` — strip keeps association COPY rows
- [ ] Re-run postgresql → timescaledb restore with dirty reminders dump; expect associations present and verify pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

