### PR TITLE
fix: clear Timescale catalog seeds before logical dump restore

### DIFF
--- a/app/services/native_migration/sql_staging.py
+++ b/app/services/native_migration/sql_staging.py
@@ -12,15 +12,15 @@ from app.services.pasarguard_ops import resolve_db_service, docker_compose_up, _
 
 
 def _filter_timescaledb_extension_sql(sql: str) -> str:
-    """Strip CREATE/DROP EXTENSION timescaledb lines (handled around import)."""
-    return "\n".join(
-        ln for ln in sql.splitlines()
-        if not re.search(
-            r"^\s*(DROP|CREATE)\s+EXTENSION\s+(IF\s+(EXISTS|NOT\s+EXISTS)\s+)?timescaledb\b",
-            ln,
-            re.I,
-        )
-    )
+    """Strip CREATE/DROP EXTENSION timescaledb and clear extension catalog seeds.
+
+    Staging creates the extension before import; dumps still COPY metadata rows
+    like install_timestamp. Reuse the shared Timescale→Timescale filter so
+    metadata_pkey collisions cannot abort staging the way panel restore used to.
+    """
+    from app.services.pg_restore import filter_timescaledb_extension_sql
+
+    return filter_timescaledb_extension_sql(sql, strip_all=False)
 
 
 def _compose_has_service(name: str) -> bool:
@@ -319,13 +319,16 @@ async def _import_via_compose_service(
     filtered: Path | None = None
     import_path = dump_path
     if use_ts:
+        from app.services.pg_restore import TIMESCALEDB_CATALOG_SEED_CLEAR_SQL
+
         for sql in (
             "CREATE EXTENSION IF NOT EXISTS timescaledb;",
             "SELECT timescaledb_pre_restore();",
+            TIMESCALEDB_CATALOG_SEED_CLEAR_SQL,
         ):
             p = await asyncio.create_subprocess_shell(
                 f'cd "{cwd}" && docker compose exec -T {service} '
-                f'env PGPASSWORD="{pwd}" psql -U {user} -d {staging_db} -c "{sql}"'
+                f'env PGPASSWORD="{pwd}" psql -U {user} -d {staging_db} -c {repr(sql)}'
             )
             await p.wait()
         filtered = dump_path.with_suffix(dump_path.suffix + ".staging-filtered")
@@ -853,6 +856,8 @@ async def _import_via_ephemeral_postgres(
         import_path = dump_path
         filtered: Path | None = None
         if use_ts:
+            from app.services.pg_restore import TIMESCALEDB_CATALOG_SEED_CLEAR_SQL
+
             await _psql_ephemeral_retry(
                 container, pwd, staging_db,
                 "CREATE EXTENSION IF NOT EXISTS timescaledb;",
@@ -860,6 +865,11 @@ async def _import_via_ephemeral_postgres(
             await _psql_ephemeral_retry(
                 container, pwd, staging_db,
                 "SELECT timescaledb_pre_restore();",
+                on_error_stop=False,
+            )
+            await _psql_ephemeral_retry(
+                container, pwd, staging_db,
+                TIMESCALEDB_CATALOG_SEED_CLEAR_SQL,
                 on_error_stop=False,
             )
             filtered = dump_path.with_suffix(dump_path.suffix + ".ephemeral-filtered")

--- a/app/services/pg_restore.py
+++ b/app/services/pg_restore.py
@@ -103,15 +103,74 @@ def extract_psql_errors(text: str, limit: int = 12) -> str:
     return "\n".join(lines[:limit])
 
 
+# CREATE EXTENSION timescaledb inserts seed rows (install_timestamp, default
+# bgw jobs, …). Logical dumps COPY the same PKs and abort with metadata_pkey /
+# bgw_job_pkey on builds without the newer upsert trigger. Clear those seeds
+# before dump import so COPY can reload catalog data from the backup.
+TIMESCALEDB_CATALOG_SEED_CLEAR_SQL = """\
+-- PGClockMG: clear extension-seeded Timescale catalog rows before dump COPY
+DO $pgclockmg_ts_catalog$
+DECLARE
+  r regclass;
+BEGIN
+  FOR r IN
+    SELECT (quote_ident(n.nspname) || '.' || quote_ident(c.relname))::regclass
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'r'
+      AND n.nspname LIKE '\\_timescaledb%' ESCAPE '\\'
+      AND c.relname IN (
+        'bgw_job_stat_history',
+        'bgw_job_stat',
+        'bgw_job',
+        'metadata'
+      )
+    ORDER BY CASE c.relname
+      WHEN 'bgw_job_stat_history' THEN 1
+      WHEN 'bgw_job_stat' THEN 2
+      WHEN 'bgw_job' THEN 3
+      WHEN 'metadata' THEN 4
+      ELSE 5
+    END
+  LOOP
+    EXECUTE format('DELETE FROM %s', r);
+  END LOOP;
+END
+$pgclockmg_ts_catalog$;
+"""
+
+
+def logs_indicate_timescaledb_catalog_seed_conflict(text: str) -> bool:
+    """True when dump import hit extension-seeded catalog PK collisions."""
+    low = (text or "").lower()
+    if "metadata_pkey" in low:
+        return True
+    if "duplicate key" in low and "install_timestamp" in low:
+        return True
+    if "duplicate key" in low and "exported_uuid" in low:
+        return True
+    if "duplicate key" in low and re.search(r"\bcopy\s+metadata\b", low):
+        return True
+    if "duplicate key" in low and "bgw_job" in low:
+        return True
+    return False
+
+
 def filter_timescaledb_extension_sql(sql: str, *, strip_all: bool = False) -> str:
     """Strip TimescaleDB extension / toolkit DDL that plain PostgreSQL cannot run.
 
     When restoring a Timescale backup into stock PostgreSQL, set strip_all=True to
     also drop hypertable helpers and any other timescaledb-qualified statements.
+
+    For Timescale→Timescale restores (strip_all=False), prepend catalog seed
+    clear so CREATE EXTENSION's install_timestamp does not collide with dump COPY.
     """
-    return "\n".join(
+    body = "\n".join(
         ln for ln in sql.splitlines() if not _ts_extension_line_dropped(ln, strip_all)
     )
+    if strip_all:
+        return body
+    return TIMESCALEDB_CATALOG_SEED_CLEAR_SQL.rstrip() + "\n" + body
 
 
 def _ts_extension_line_dropped(ln: str, strip_all: bool) -> bool:
@@ -161,6 +220,9 @@ def filter_timescaledb_extension_sql_file(
     """Stream `src` into `dest`, dropping the same lines as the in-memory filter."""
     with open(src, "r", encoding="utf-8", errors="ignore") as fh, \
             open(dest, "w", encoding="utf-8") as out:
+        if not strip_all:
+            out.write(TIMESCALEDB_CATALOG_SEED_CLEAR_SQL.rstrip())
+            out.write("\n")
         for raw in fh:
             ln = raw.rstrip("\n").rstrip("\r")
             if _ts_extension_line_dropped(ln, strip_all):
@@ -4852,11 +4914,42 @@ async def _restore_postgres(
                         f"{extract_psql_errors(out_ext)}"
                     )
                 await psql("SELECT timescaledb_pre_restore();", db=dbn)
+                await psql(TIMESCALEDB_CATALOG_SEED_CLEAR_SQL, db=dbn)
                 filtered = filter_timescaledb_extension_sql_file(
                     dump_path, dump_path.with_suffix(dump_path.suffix + ".filtered"),
                 )
                 restore_file = filtered
                 ok, out = await restore_dump_file(dbn, restore_file, tolerant=False)
+                if (
+                    not ok
+                    and logs_indicate_timescaledb_catalog_seed_conflict(out or "")
+                ):
+                    job.log(
+                        "Timescale catalog seed conflict during dump import — "
+                        "recreating database and retrying with cleared seeds…"
+                    )
+                    await psql(f'DROP DATABASE IF EXISTS "{dbn}";')
+                    ok_re, out_re = await psql(
+                        f'CREATE DATABASE "{dbn}" OWNER "{owner_q}";'
+                    )
+                    if not ok_re:
+                        raise RuntimeError(
+                            f"CREATE DATABASE {dbn} failed on catalog-seed retry:\n"
+                            f"{out_re[-1000:]}"
+                        )
+                    await psql(
+                        "CREATE EXTENSION IF NOT EXISTS timescaledb;", db=dbn,
+                    )
+                    await psql("SELECT timescaledb_pre_restore();", db=dbn)
+                    await psql(TIMESCALEDB_CATALOG_SEED_CLEAR_SQL, db=dbn)
+                    filtered = filter_timescaledb_extension_sql_file(
+                        dump_path,
+                        dump_path.with_suffix(dump_path.suffix + ".filtered"),
+                    )
+                    restore_file = filtered
+                    ok, out = await restore_dump_file(
+                        dbn, restore_file, tolerant=False,
+                    )
                 ok_post, out_post = await psql("SELECT timescaledb_post_restore();", db=dbn)
                 if not ok_post:
                     job.log(f"timescaledb_post_restore warning: {extract_psql_errors(out_post)[:300]}")
@@ -4903,6 +4996,7 @@ async def _restore_postgres(
                             )
                         await psql("CREATE EXTENSION IF NOT EXISTS timescaledb;", db=dbn)
                         await psql("SELECT timescaledb_pre_restore();", db=dbn)
+                        await psql(TIMESCALEDB_CATALOG_SEED_CLEAR_SQL, db=dbn)
                         filtered2 = filter_timescaledb_extension_sql_file(
                             dump_path, dump_path.with_suffix(dump_path.suffix + ".filtered"),
                         )
@@ -4973,10 +5067,34 @@ async def _restore_postgres(
                 f"Target cannot create timescaledb extension:\n{extract_psql_errors(out_ext)}"
             )
         await psql("SELECT timescaledb_pre_restore();", db=db_name)
+        await psql(TIMESCALEDB_CATALOG_SEED_CLEAR_SQL, db=db_name)
         filtered = filter_timescaledb_extension_sql_file(
             dump, root / "db_backup_filtered.sql",
         )
         ok, out = await restore_dump_file(db_name, filtered, tolerant=False)
+        if (
+            not ok
+            and logs_indicate_timescaledb_catalog_seed_conflict(out or "")
+        ):
+            job.log(
+                "Timescale catalog seed conflict during single-dump import — "
+                "recreating database and retrying with cleared seeds…"
+            )
+            await psql(
+                f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{db_name}' AND pid <> pg_backend_pid();"
+            )
+            await psql(f'DROP DATABASE IF EXISTS "{db_name}";')
+            ok_re, out_re = await psql(f'CREATE DATABASE "{db_name}" OWNER "{user}";')
+            if not ok_re:
+                raise RuntimeError(
+                    f"CREATE DATABASE failed on catalog-seed retry:\n{out_re[-1000:]}"
+                )
+            await psql("CREATE EXTENSION IF NOT EXISTS timescaledb;", db=db_name)
+            await psql("SELECT timescaledb_pre_restore();", db=db_name)
+            await psql(TIMESCALEDB_CATALOG_SEED_CLEAR_SQL, db=db_name)
+            filter_timescaledb_extension_sql_file(dump, filtered)
+            ok, out = await restore_dump_file(db_name, filtered, tolerant=False)
         if not ok:
             wanted = wanted_ts_for_restore_retry(out or "", analysis) or ""
             if not wanted and is_ts_catalog_mismatch_error(out or ""):
@@ -5002,6 +5120,7 @@ async def _restore_postgres(
                     )
                 await psql("CREATE EXTENSION IF NOT EXISTS timescaledb;", db=db_name)
                 await psql("SELECT timescaledb_pre_restore();", db=db_name)
+                await psql(TIMESCALEDB_CATALOG_SEED_CLEAR_SQL, db=db_name)
                 filter_timescaledb_extension_sql_file(dump, filtered)
                 ok, out = await restore_dump_file(db_name, filtered, tolerant=False)
         ok_post_s, out_post_s = await psql("SELECT timescaledb_post_restore();", db=db_name)

--- a/tests/test_pg_restore.py
+++ b/tests/test_pg_restore.py
@@ -12,6 +12,9 @@ sys.path.insert(0, str(ROOT))
 from app.services.pg_restore import (
     soft_db_family,
     filter_timescaledb_extension_sql,
+    filter_timescaledb_extension_sql_file,
+    logs_indicate_timescaledb_catalog_seed_conflict,
+    TIMESCALEDB_CATALOG_SEED_CLEAR_SQL,
     filter_globals_sql,
     parse_timescale_wanted,
     detect_ts_mismatch_from_text,
@@ -427,12 +430,21 @@ def test_filter_timescaledb_extension_sql():
         "CREATE EXTENSION timescaledb CASCADE;",
         "CREATE EXTENSION IF NOT EXISTS timescaledb;",
         "DROP EXTENSION IF EXISTS timescaledb;",
+        "COPY metadata (key, value, include_in_telemetry) FROM stdin;",
+        "install_timestamp\t2026-06-13 14:38:48.338307+00\tt",
+        "\\.",
         "INSERT INTO t VALUES (1);",
     ])
     out = filter_timescaledb_extension_sql(sql)
     assert "CREATE TABLE" in out
     assert "INSERT INTO" in out
-    assert "timescaledb" not in out.lower()
+    assert "COPY metadata" in out
+    assert "install_timestamp" in out
+    assert "CREATE EXTENSION" not in out
+    assert "DROP EXTENSION" not in out
+    # Timescale→Timescale keeps dump rows but clears extension seeds first.
+    assert "pgclockmg_ts_catalog" in out
+    assert out.index("pgclockmg_ts_catalog") < out.index("COPY metadata")
     print("OK: filter timescaledb extension sql")
 
 
@@ -450,7 +462,50 @@ def test_filter_timescaledb_strip_all_for_plain_pg():
     assert "INSERT INTO users" in out
     assert "timescaledb" not in out.lower()
     assert "create_hypertable" not in out.lower()
+    assert "pgclockmg_ts_catalog" not in out
     print("OK: strip_all timescaledb for plain PostgreSQL")
+
+
+def test_timescaledb_catalog_seed_conflict_detection_and_file_filter():
+    import tempfile
+    import shutil
+
+    err = (
+        'Failed restoring pasarguard: ERROR:  duplicate key value violates '
+        'unique constraint "metadata_pkey"\n'
+        "DETAIL:  Key (key)=(install_timestamp) already exists.\n"
+        'CONTEXT:  COPY metadata, line 1: "install_timestamp\t2026-06-13..."'
+    )
+    assert logs_indicate_timescaledb_catalog_seed_conflict(err)
+    assert logs_indicate_timescaledb_catalog_seed_conflict(
+        'ERROR: duplicate key value violates unique constraint "bgw_job_pkey"'
+    )
+    assert not logs_indicate_timescaledb_catalog_seed_conflict(
+        "ERROR: relation users does not exist"
+    )
+    assert "DELETE FROM" in TIMESCALEDB_CATALOG_SEED_CLEAR_SQL
+    assert "metadata" in TIMESCALEDB_CATALOG_SEED_CLEAR_SQL
+
+    td = Path(tempfile.mkdtemp(prefix="pg-ts-meta-"))
+    try:
+        src = td / "in.sql"
+        dest = td / "out.sql"
+        src.write_text(
+            "CREATE EXTENSION IF NOT EXISTS timescaledb;\n"
+            "COPY metadata (key) FROM stdin;\n"
+            "install_timestamp\n"
+            "\\.\n",
+            encoding="utf-8",
+        )
+        filter_timescaledb_extension_sql_file(src, dest)
+        body = dest.read_text(encoding="utf-8")
+        assert "pgclockmg_ts_catalog" in body
+        assert "CREATE EXTENSION" not in body
+        assert "COPY metadata" in body
+        assert body.index("pgclockmg_ts_catalog") < body.index("COPY metadata")
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+    print("OK: timescale catalog seed conflict detection + file filter")
 
 
 def test_parse_timescale_wanted():
@@ -1354,6 +1409,7 @@ if __name__ == "__main__":
     test_parse_ts_post_restore_catalog_mismatch()
     test_filter_timescaledb_extension_sql()
     test_filter_timescaledb_strip_all_for_plain_pg()
+    test_timescaledb_catalog_seed_conflict_detection_and_file_filter()
     test_parse_timescale_wanted()
     test_detect_ts_mismatch_from_official_error()
     test_is_ts_catalog_mismatch_error_schema_name()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- After `CREATE EXTENSION timescaledb`, clear extension-seeded catalog rows (`metadata` / default `bgw_job*`) before dump import so `COPY metadata` no longer hits `metadata_pkey` on `install_timestamp`.
- Inject the same clear into filtered Timescale→Timescale dumps; keep strip-all plain-PG path unchanged.
- Auto-retry once on catalog-seed PK conflicts (multi + single dump paths).
- Mirror prepare/clear in SQL staging imports.

## Why
Logical Timescale restores create the extension first (required), which seeds `install_timestamp`. The dump then COPYs the same key → hard fail. This is a restore-path gap, not a bad backup.

## Test plan
- [x] `python3 tests/test_pg_restore.py`
- [x] `python3 tests/test_marzban_preboot_heal.py`
- [ ] Re-run affected Timescale restore after v4.5.5 upgrade

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08d6d-b66e-728f-a6b5-83df7b81a17f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

